### PR TITLE
Fix starter url path

### DIFF
--- a/hellochain/tutorial/00-intro.md
+++ b/hellochain/tutorial/00-intro.md
@@ -15,7 +15,7 @@ functionality in the form of our `greeter` module.
 ### Starter
 
 To speed up this tutorial, A lot of basic functionality comes packaged for you
-in the [starter](https://github.com/cosmos/sdk-tutorials/hellochain/starter)
+in the [starter](https://github.com/cosmos/sdk-tutorials/tree/master/hellochain/starter)
 package. It will provide basic accounts, a bank, authentication, transaction
 (Tx) verification as well as some helper functions for building CLI tools.
 `starter` is your "crutch" for this tutorial. It is a heavily configured


### PR DESCRIPTION
Updated `starter` url to  https://github.com/cosmos/sdk-tutorials/tree/master/hellochain/starter