### PR TITLE
provide a setup document, re #221

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 _[The code for these tutorials (and this site) can be found here on Github](https://www.github.com/cosmos/sdk-tutorials)_
 
+## Prerequisites
+
+After a quick [Development Environment Setup](SETUP.md), you're ready to select a tutorial from the list below.
+
 ## [Hellochain](./hellochain/tutorial/00-intro.md)
 
 This is the quick and simple "Hello World" introduction to building with the Cosmos SDK. You will build a fully-funcitonal blockchain with payment functionality and a custom "greeter" module. This tutorial makes use of the `utils/starter` package to reduce boilerplate and allow you to focus on the core concepts. Start here if you are evaluating Cosmos as your possible platform of choice.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,27 @@
+# Development Environment Setup
+
+## Supported OS
+
+The example instructions are for Ubuntu 18.04 and for any other OS using ubuntu on a virtual machine (Windows: WSL, VirtualBox, Docker.
+
+Native setup on other *nix systems should be similar.
+
+Windows native is not tested/supported, use WSL (Windows Subsystem for Linux) or another virtual machine running ubuntu 18.04.
+
+## Setup
+
+
+The go-language 1.13 and higher (for full info: [official go download page](https://golang.org/dl/) )
+
+```sh
+sudo add-apt-repository ppa:longsleep/golang-backports
+sudo apt-get update
+sudo apt-get install golang-go
+
+go version  # should be go1.13.x
+
+# add go env GOPATH to the system PATH
+echo 'export PATH=$PATH:$(go env GOPATH)/bin' >> ~/.profile
+source ~/.profile
+```
+

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,17 +1,10 @@
 # Development Environment Setup
 
-## Supported OS
+You'll need `go-lang 1.13.x`, `git` and `make` on your machine.
 
-The example instructions are for Ubuntu 18.04 and for any other OS using ubuntu on a virtual machine (Windows: WSL, VirtualBox, Docker.
+Use an Editor or an IDE of your choice, e.g. [Visual Studio Code](https://code.visualstudio.com/download).
 
-Native setup on other *nix systems should be similar.
-
-Windows native is not tested/supported, use WSL (Windows Subsystem for Linux) or another virtual machine running ubuntu 18.04.
-
-## Setup
-
-
-The go-language 1.13 and higher (for full info: [official go download page](https://golang.org/dl/) )
+## Ubuntu 18.04
 
 ```sh
 sudo add-apt-repository ppa:longsleep/golang-backports
@@ -24,4 +17,26 @@ go version  # should be go1.13.x
 echo 'export PATH=$PATH:$(go env GOPATH)/bin' >> ~/.profile
 source ~/.profile
 ```
+
+`git` and `make` are already installed, if not:
+
+```sh
+sudo apt-get install git make
+```
+
+## Other *nix, Mac
+
+Use the package-manager of your system.
+
+## Windows
+
+Windows native is not tested/supported.
+
+You can use WSL (Windows Subsystem for Linux) or another virtual machine running ubuntu 18.04.
+
+## All OS
+
+Visit the [official golang download page](https://golang.org/dl/)
+
+
 


### PR DESCRIPTION
Adding basic setup instructions.

Going through `hellochain` becomes now as easy as in:

```sh
git clone https://github.com/cosmos/sdk-tutorials.git
cd sdk-tutorials/hellochain
make install
hcd
hccli
```

then continue with the "try-it-out" section.

=> zero hassle

