### PR TITLE
Update query.go

### DIFF
--- a/hellochain/x/greeter/client/cli/query.go
+++ b/hellochain/x/greeter/client/cli/query.go
@@ -52,7 +52,7 @@ func GetCmdListGreetings(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			route := fmt.Sprintf("custom/%s/list/%s", queryRoute, addr)
 			res, _, err := cliCtx.QueryWithData(route, nil)
 			if err != nil {
-				return nil
+				return err
 			}
 
 			out := gtypes.NewQueryResGreetings()


### PR DESCRIPTION
An error should be returned here to let the user know if unexpected behavior has occurred