### PR TITLE
Support multiple tags for tutorials

### DIFF
--- a/.vuepress/components/Home.vue
+++ b/.vuepress/components/Home.vue
@@ -11,7 +11,8 @@
     .sections__wrapper
       .sections
         router-link.sections__item(tag="a" :to="section.url" v-for="section in $frontmatter.sections")
-          .sections__item__tag(:style="{'--tag-text-color': `${tagColor[section.tag][0]}`, '--tag-background-color': `${tagColor[section.tag][1]}`}") {{section.tag}}
+          .sections__item__tags
+            .sections__item__tags__item(:style="{'--tag-text-color': `${tagColor[tag][0]}`, '--tag-background-color': `${tagColor[tag][1]}`}" v-for="tag in section.tags") {{tag}}
           .sections__item__wrapper
             .sections__item__title {{section.title}}
             .sections__item__desc {{section.desc}}
@@ -30,22 +31,16 @@ export default {
   data() {
     return {
       tagColor: {
-        beginner: [
-          '#5064FB',
-          '#FFFFFF',
-        ],
-        intermediate: [
-          '#FFFFFF',
-          '#5064FB',
-        ],
-        advanced: [
-          '#FFFFFF',
-          'rgba(0, 2, 36, 0.928)',
-        ],
+        beginner: ["#5064FB", "#FFFFFF"],
+        intermediate: ["#FFFFFF", "#5064FB"],
+        advanced: ["#FFFFFF", "rgba(0, 2, 36, 0.928)"],
+        launchpad: ["#FFFFFF", "rgba(0, 2, 36, 0.928)"],
+        stargate: ["#FFFFFF", "rgba(0, 2, 36, 0.928)"],
+        starport: ["#FFFFFF", "rgba(0, 2, 36, 0.928)"],
       },
-    }
-  }
-}
+    };
+  },
+};
 </script>
 
 <style lang="stylus" scoped>
@@ -154,16 +149,23 @@ a
       opacity: 0.7;
     }
 
-    &__tag {
-      color: var(--tag-text-color);
-      font-size: 0.875rem;
-      line-height: 1.25rem;
-      letter-spacing: 0.03em;
-      text-transform: capitalize;
-      background: var(--tag-background-color);
-      border-radius: 0.25rem;
-      padding: 0.125rem 0.5rem;
-      width: fit-content;
+    &__tags {
+      display: flex;
+      flex-direction: row;
+
+      &__item {
+        margin-left: 0.5rem;
+        color: var(--tag-text-color);
+        font-size: 0.875rem;
+        line-height: 1.25rem;
+        letter-spacing: 0.03em;
+        text-transform: capitalize;
+        background: var(--tag-background-color);
+        border-radius: 0.25rem;
+        padding: 0.125rem 0.5rem;
+        width: fit-content;
+      }
+
     }
 
     &__title {

--- a/.vuepress/components/Home.vue
+++ b/.vuepress/components/Home.vue
@@ -154,7 +154,7 @@ a
       flex-direction: row;
 
       &__item {
-        margin-left: 0.5rem;
+        margin-right: 0.5rem;
         color: var(--tag-text-color);
         font-size: 0.875rem;
         line-height: 1.25rem;
@@ -162,7 +162,7 @@ a
         text-transform: capitalize;
         background: var(--tag-background-color);
         border-radius: 0.25rem;
-        padding: 0.125rem 0.5rem;
+        padding: 0.25rem 0.5rem 0.125rem;
         width: fit-content;
       }
 

--- a/.vuepress/components/Home.vue
+++ b/.vuepress/components/Home.vue
@@ -34,9 +34,9 @@ export default {
         beginner: ["#5064FB", "#FFFFFF"],
         intermediate: ["#FFFFFF", "#5064FB"],
         advanced: ["#FFFFFF", "rgba(0, 2, 36, 0.928)"],
-        launchpad: ["#FFFFFF", "rgba(0, 2, 36, 0.928)"],
-        stargate: ["#FFFFFF", "rgba(0, 2, 36, 0.928)"],
-        starport: ["#FFFFFF", "rgba(0, 2, 36, 0.928)"],
+        launchpad: ["#FFFFFF", "#3D60A4"],
+        stargate: ["#FFFFFF", "#AC454C"],
+        starport: ["#FFFFFF", "#7A236C"],
       },
     };
   },
@@ -150,10 +150,11 @@ a
     }
 
     &__tags {
-      display: flex;
       flex-direction: row;
 
       &__item {
+        display: inline-block;
+        margin-bottom: 0.5rem;
         margin-right: 0.5rem;
         color: var(--tag-text-color);
         font-size: 0.875rem;

--- a/README.md
+++ b/README.md
@@ -6,23 +6,36 @@ sections:
   - title: Voter
     desc: Build a voting application with a web-based UI.
     url: /voter/
-    tag: beginner
+    tags: 
+      - beginner
+      - starport
+      - launchpad
   - title: Blog
     desc: Learn how Starport works by building a blog.
     url: /blog/tutorial/01-index.html
-    tag: beginner
+    tags: 
+      - beginner
+      - starport
+      - launchpad
   - title: Scavenge
     desc: Users post questions with hashed answers and bounties for whoever can solve them using a commit-reveal scheme that prevents front-running.
     url: /scavenge/tutorial/01-background.html
-    tag: intermediate
+    tags: 
+      - intermediate
+      - starport
+      - launchpad
   - title: Nameservice
     desc: Build a fully functional naming service on a blockchain.
     url: /nameservice/tutorial/00-intro.html
-    tag: advanced
+    tags: 
+      - advanced
+      - starport
+      - launchpad
   - title: Cosmos Burner Chain
     desc: Provide a blueprint for your own application specific blockchain that interacts with other EVM based networks like Ethereum and xDai.
     url: /burner-chain/00-index.html
-    tag: advanced
+    tags: 
+      - advanced
 stack:
   - title: Cosmos Code With Us - Building your first Cosmos app
     duration: "1:39:07"


### PR DESCRIPTION
We should start tagging our tutorials with more relevant information rather than just the difficulty (currently `Beginner`, `Intermediate`, `Advanced`).

This PR implements support of multiple tags and the addition of tags `Launchpad`, `Stargate`, and `Starport`.