### PR TITLE
Update nameservice 03-types with `whois`

### DIFF
--- a/nameservice/tutorial/03-types.md
+++ b/nameservice/tutorial/03-types.md
@@ -8,7 +8,7 @@ First thing we're going to do is create a type in the `/x/nameservice` folder wi
 
 
 ```bash
-starport type name value price
+starport type whois value price
 ```
 
 Currently, we're only passing two values when scaffolding the `whois` type, because there are additional fields that we will be replacing. In all uses of `whois`, we'll be removing the auto-generated `ID` field, and replacing the `Creator` field with `Owner` to reflect ownership of the name.

--- a/nameservice/tutorial/03-types.md
+++ b/nameservice/tutorial/03-types.md
@@ -11,7 +11,7 @@ First thing we're going to do is create a type in the `/x/nameservice` folder wi
 starport type whois value price
 ```
 
-Currently, we're only passing two values when scaffolding the `whois` type, because there are additional fields that we will be replacing. In all uses of `whois`, we'll be removing the auto-generated `ID` field, and replacing the `Creator` field with `Owner` to reflect ownership of the name.
+Currently, we're only passing two values when scaffolding the `whois` type, because there are additional fields that we will be replacing. In all uses of `whois`, we'll be removing the auto-generated `ID` field and replacing the `Creator` field with `Owner` to reflect ownership of the name.
 
 ## `types.go`
 


### PR DESCRIPTION
Make it clear to the user that `whois` should be added with the `starport type` command