### PR TITLE
Add versions to Starport install instructions

### DIFF
--- a/blog/tutorial/01-index.md
+++ b/blog/tutorial/01-index.md
@@ -8,7 +8,7 @@ By following this beginner tutorial, you will end up with a simple blog app that
 
 ## Requirements 
 
-For this tutorial we will be using Starport v0.0.10, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
+For this tutorial we will be using [Starport](https://github.com/tendermint/starport) v0.0.10, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
 
 ```
 curl https://i.jpillora.com/tendermint/starport@v0.0.10! | bash

--- a/blog/tutorial/01-index.md
+++ b/blog/tutorial/01-index.md
@@ -6,10 +6,15 @@ order: 1
 
 By following this beginner tutorial, you will end up with a simple blog app that is powered by the Cosmos SDK.
 
-## Prerequisites
+## Requirements 
 
-- A [recent version of Go](https://golang.org/doc/install) installed.
-- [Node.js](https://nodejs.org/) installed.
+For this tutorial we will be using Starport v0.0.10, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
+
+```
+curl https://i.jpillora.com/tendermint/starport@v0.0.10! | bash
+```
+
+You can also use Starport v0.0.10 on the web in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.0.10). Learn more about other ways to [install Starport](https://github.com/tendermint/starport/blob/develop/docs/1%20Introduction/2%20Install.md).
 
 ## Getting Started
 
@@ -18,7 +23,7 @@ Let's get started! The first step is to [install the `starport`](https://github.
 After `starport` is installed, use it to create the initial app structure inside a directory named `blog`:
 
 ```
-starport app github.com/example/blog --sdk-version="launchpad"
+starport app github.com/example/blog
 ```
 
 One of the main features of Starport is code generation. The command above has generated a directory structure with a working blockchain application. Starport can also add data types to your app with `starport type` command. To see it in action, follow the poll application tutorial. In this guide, however, we'll create those files manually to understand how it all works under the hood.

--- a/nameservice/tutorial/00-intro.md
+++ b/nameservice/tutorial/00-intro.md
@@ -15,11 +15,14 @@ All of the final source code for this tutorial project is in this directory (and
 - [`golang` >1.13.0](https://golang.org/doc/install) installed
 - Github account and either [Github CLI](https://hub.github.com/) or [Github Desktop (64-bit required)](https://help.github.com/en/desktop/getting-started-with-github-desktop/installing-github-desktop)
 - Desire to create your own blockchain!
-- The [starport tool](https://github.com/tendermint/starport) will be used to go through this tutorial. The fastest way to install it is via npm (`npm i -g @tendermint/starport`) or brew (`brew install tendermint/tap/starport`). You could also clone the repository and build it from source - 
+
+For this tutorial we will be using [Starport](https://github.com/tendermint/starport) v0.0.10, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
 
 ```
-git clone https://github.com/tendermint/starport && cd starport && make
+curl https://i.jpillora.com/tendermint/starport@v0.0.10! | bash
 ```
+
+You can also use Starport v0.0.10 on the web in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.0.10). Learn more about other ways to [install Starport](https://github.com/tendermint/starport/blob/develop/docs/1%20Introduction/2%20Install.md).
 
 ## Tutorial
 

--- a/proof-of-file-existence/tutorial/01-intro.md
+++ b/proof-of-file-existence/tutorial/01-intro.md
@@ -30,7 +30,7 @@ Our application is relatively simple - we want to implement a blockchain where a
 
 ## Requirements 
 
-For this tutorial we will be using Starport v0.12.0, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
+For this tutorial we will be using [Starport](https://github.com/tendermint/starport) v0.12.0, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
 
 ```
 curl https://i.jpillora.com/tendermint/starport@v0.12.0! | bash

--- a/proof-of-file-existence/tutorial/01-intro.md
+++ b/proof-of-file-existence/tutorial/01-intro.md
@@ -28,27 +28,14 @@ The SHA256 hash of the file is also known as a checksum. When uploading the chec
 
 Our application is relatively simple - we want to implement a blockchain where a user can choose a file, hash its contents, and upload the file to the blockchain directly. We also want to give the owner the ability to revoke the claim.
 
-## Requirements
+## Requirements 
 
-[Starport](https://github.com/tendermint/starport/blob/develop/docs/01%20Introduction/01_starport_introduction/introduction.md) is a tool for scaffolding custom blockchains.
-
-First, we need to [install `starport`](https://github.com/tendermint/starport/blob/develop/docs/install.md), via `npm`, `brew`, or via source:
-```
-npm install -g @tendermint/starport
-```
+For this tutorial we will be using Starport v0.12.0, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
 
 ```
-brew install tendermint/tap/starport
+curl https://i.jpillora.com/tendermint/starport@v0.12.0! | bash
 ```
 
-```
-git clone https://github.com/tendermint/starport && cd starport && make
-```
-
-Alternatively, you can set up a one-click in-browser [Starport environment](https://gitpod.io/#https://github.com/tendermint/starport/).
-
-```
-https://gitpod.io/#https://github.com/tendermint/starport/
-```
+You can also use Starport v0.12.0 on the web in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.12.0). Learn more about other ways to [install Starport](https://github.com/tendermint/starport/blob/develop/docs/1%20Introduction/2%20Install.md).
 
 Now, we can start building our app!

--- a/scavenge/tutorial/03-starport-scaffolding.md
+++ b/scavenge/tutorial/03-starport-scaffolding.md
@@ -5,7 +5,7 @@ order: 3
 # Starport
 ## Requirements 
 
-For this tutorial we will be using Starport v0.0.10, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
+For this tutorial we will be using [Starport](https://github.com/tendermint/starport) v0.0.10, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
 
 ```
 curl https://i.jpillora.com/tendermint/starport@v0.0.10! | bash

--- a/scavenge/tutorial/03-starport-scaffolding.md
+++ b/scavenge/tutorial/03-starport-scaffolding.md
@@ -3,26 +3,17 @@ order: 3
 ---
 
 # Starport
+## Requirements 
 
-We'll be using a tool called [starport](https://github.com/tendermint/starport) to help us spin up a boilerplate app quickly. 
+For this tutorial we will be using Starport v0.0.10, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
 
-You can install `starport` via `npm`, `brew`, or building it from [source](https://github.com/tendermint/starport).
-
-#### npm install
-```bash
-npm i -g @tendermint/starport
+```
+curl https://i.jpillora.com/tendermint/starport@v0.0.10! | bash
 ```
 
-#### homebrew installation
-```bash
-brew install tendermint/tap/starport
-```
+You can also use Starport v0.0.10 on the web in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.0.10). Learn more about other ways to [install Starport](https://github.com/tendermint/starport/blob/develop/docs/1%20Introduction/2%20Install.md).
 
-#### building from source
-```bash
-git clone https://github.com/tendermint/starport && cd starport && make
-```
-
+## Creating a blockchain
 
 Afterwards, you can enter in `starport` in your terminal, and should see the following help text displayed:
 ```sh

--- a/voter/index.md
+++ b/voter/index.md
@@ -10,7 +10,7 @@ We will be creating a simple poll application, in which a user can sign in, crea
 
 ## Requirements 
 
-For this tutorial we will be using Starport v0.0.10, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
+For this tutorial we will be using [Starport](https://github.com/tendermint/starport) v0.0.10, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
 
 ```
 curl https://i.jpillora.com/tendermint/starport@v0.0.10! | bash

--- a/voter/index.md
+++ b/voter/index.md
@@ -2,17 +2,28 @@
 order: 1
 ---
 
-
 # Polling app
 
 ![Application screenshot](./1.png)
 
 We will be creating a simple poll application, in which a user can sign in, create polls, cast votes and see voting results. Creating a poll will cost 200 tokens, voting is free, and both actions will be available only for signed in users.
 
-For this tutorial we will be using [Starport](https://github.com/tendermint/starport), an easy to use tool for building blockchains. [Install Starport](https://github.com/tendermint/starport#installation) and run the following command to create a voter project:
+## Requirements 
+
+For this tutorial we will be using Starport v0.0.10, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:
 
 ```
-starport app github.com/alice/voter --sdk-version="launchpad"
+curl https://i.jpillora.com/tendermint/starport@v0.0.10! | bash
+```
+
+You can also use Starport v0.0.10 on the web in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.0.10). Learn more about other ways to [install Starport](https://github.com/tendermint/starport/blob/develop/docs/1%20Introduction/2%20Install.md).
+
+## Creating a blockchain
+
+Run the following command to create a voter project:
+
+```
+starport app github.com/alice/voter
 ```
 
 Starport `app` command will scaffold a project structure for your application in a `voter` directory. Make sure to replace `alice` with your GitHub username.


### PR DESCRIPTION
Adds versioned install instructions to each tutorial:

---

## Requirements 

For this tutorial we will be using Starport v0.12.0, an easy to use tool for building blockchains. To install `starport` into `/usr/local/bin`, run the following command:

```
curl https://i.jpillora.com/tendermint/starport@v0.12.0! | bash
```

You can also use Starport v0.12.0 on the web in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.12.0). Learn more about other ways to [install Starport](https://github.com/tendermint/starport/blob/develop/docs/1%20Introduction/2%20Install.md).

---

This makes sure that no one has difficulties going through tutorials, even if we update templates in Starport.

close https://github.com/cosmos/sdk-tutorials/issues/481