### PR TITLE
Starport add sdk version

### DIFF
--- a/blog/tutorial/01-index.md
+++ b/blog/tutorial/01-index.md
@@ -23,7 +23,7 @@ Let's get started! The first step is to [install the `starport`](https://github.
 After `starport` is installed, use it to create the initial app structure inside a directory named `blog`:
 
 ```
-starport app github.com/example/blog
+starport app github.com/example/blog --sdk-version="launchpad"
 ```
 
 One of the main features of Starport is code generation. The command above has generated a directory structure with a working blockchain application. Starport can also add data types to your app with `starport type` command. To see it in action, follow the poll application tutorial. In this guide, however, we'll create those files manually to understand how it all works under the hood.

--- a/scavenge/scavenge/Makefile
+++ b/scavenge/scavenge/Makefile
@@ -4,8 +4,8 @@ VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=NewApp \
-	-X github.com/cosmos/cosmos-sdk/version.ServerName=scavengeD \
-	-X github.com/cosmos/cosmos-sdk/version.ClientName=scavengeCLI \
+	-X github.com/cosmos/cosmos-sdk/version.ServerName=scavenged \
+	-X github.com/cosmos/cosmos-sdk/version.ClientName=scavengecli \
 	-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) 
 
@@ -16,8 +16,8 @@ all: install
 
 .PHONY: install
 install: go.sum
-		go install $(BUILD_FLAGS) ./cmd/scavengeD
-		go install $(BUILD_FLAGS) ./cmd/scavengeCLI
+		go install $(BUILD_FLAGS) ./cmd/scavenged
+		go install $(BUILD_FLAGS) ./cmd/scavengecli
 		npm --prefix ./vue i --save 
 		npm --prefix ./vue run build
 

--- a/scavenge/scavenge/happypath.sh
+++ b/scavenge/scavenge/happypath.sh
@@ -1,4 +1,4 @@
-scavengeCLI tx scavenge create-scavenge "What's brown and sticky?" "A stick" 69token --from user1 -y  | jq ".txhash" |  xargs $(sleep 5) scavengeCLI q tx
-scavengeCLI tx scavenge commit-solution "A stick" --from user2 -y | jq ".txhash" |  xargs $(sleep 5) scavengeCLI q tx
-scavengeCLI tx scavenge reveal-solution "A stick" --from user2 -y | jq ".txhash" |  xargs $(sleep 5) scavengeCLI q tx
-scavengeCLI query scavenge list-scavenge | jq ".[].solutionHash" | xargs -I {} scavengeCLI query scavenge get-scavenge {}
+scavengecli tx scavenge create-scavenge "What's brown and sticky?" "A stick" 69token --from user1 -y  | jq ".txhash" |  xargs $(sleep 5) scavengecli q tx
+scavengecli tx scavenge commit-solution "A stick" --from user2 -y | jq ".txhash" |  xargs $(sleep 5) scavengecli q tx
+scavengecli tx scavenge reveal-solution "A stick" --from user2 -y | jq ".txhash" |  xargs $(sleep 5) scavengecli q tx
+scavengecli query scavenge list-scavenge | jq ".[].solutionHash" | xargs -I {} scavengecli query scavenge get-scavenge {}

--- a/scavenge/scavenge/init.sh
+++ b/scavenge/scavenge/init.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
-rm -r ~/.scavengeCLI
-rm -r ~/.scavengeD
+rm -r ~/.scavengecli
+rm -r ~/.scavenged
 
-scavengeD init mynode --chain-id scavenge
+scavenged init mynode --chain-id scavenge
 
-scavengeCLI config keyring-backend test
-scavengeCLI config chain-id scavenge
-scavengeCLI config output json
-scavengeCLI config indent true
-scavengeCLI config trust-node true
+scavengecli config keyring-backend test
+scavengecli config chain-id scavenge
+scavengecli config output json
+scavengecli config indent true
+scavengecli config trust-node true
 
-scavengeCLI keys add user1
-scavengeCLI keys add user2
-scavengeD add-genesis-account $(scavengeCLI keys show user1 -a) 1000token,100000000stake
-scavengeD add-genesis-account $(scavengeCLI keys show user2 -a) 500token
+scavengecli keys add user1
+scavengecli keys add user2
+scavenged add-genesis-account $(scavengecli keys show user1 -a) 1000token,100000000stake
+scavenged add-genesis-account $(scavengecli keys show user2 -a) 500token
 
-scavengeD gentx --name user1 --keyring-backend test
+scavenged gentx --name user1 --keyring-backend test
 
-scavengeD collect-gentxs 
+scavenged collect-gentxs 

--- a/scavenge/tutorial/04-starport-serve.md
+++ b/scavenge/tutorial/04-starport-serve.md
@@ -40,8 +40,8 @@ VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=NewApp \
-	-X github.com/cosmos/cosmos-sdk/version.ServerName=scavengeD \
-	-X github.com/cosmos/cosmos-sdk/version.ClientName=scavengeCLI \
+	-X github.com/cosmos/cosmos-sdk/version.ServerName=scavenged \
+	-X github.com/cosmos/cosmos-sdk/version.ClientName=scavengecli \
 	-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) 
 
@@ -52,8 +52,8 @@ all: install
 
 .PHONY: install
 install: go.sum
-		go install -mod=readonly $(BUILD_FLAGS) ./cmd/scavengeD
-		go install -mod=readonly $(BUILD_FLAGS) ./cmd/scavengeCLI
+		go install -mod=readonly $(BUILD_FLAGS) ./cmd/scavenged
+		go install -mod=readonly $(BUILD_FLAGS) ./cmd/scavengecli
 		npm --prefix ./vue i --save 
 		npm --prefix ./vue run build
 

--- a/voter/index.md
+++ b/voter/index.md
@@ -23,7 +23,7 @@ You can also use Starport v0.0.10 on the web in a [browser-based IDE](http://git
 Run the following command to create a voter project:
 
 ```
-starport app github.com/alice/voter
+starport app github.com/alice/voter --sdk-version="launchpad"
 ```
 
 Starport `app` command will scaffold a project structure for your application in a `voter` directory. Make sure to replace `alice` with your GitHub username.


### PR DESCRIPTION
With starport v0.13 out, SDK version default is Stargate (v.040). Tutorials are written in Launchpad (v0.39) version, which needs to be addressed when bootstrapping a chain with starport.

Changes suggested for `voter` tutorial and `blog` tutorial