### PR TITLE
Fix and format stargate blog tutorial

### DIFF
--- a/blog/tutorial/01-index.md
+++ b/blog/tutorial/01-index.md
@@ -65,10 +65,9 @@ message MsgCreatePost {
   string title = 2; 
   string body = 3; 
 }
-
 ```
 
-The code above defines the three properties of a post: Creator, Title, Body and ID. We generate unique global IDs for each post and also store them as strings.
+The code above defines the four properties of a post: Creator, Title, Body and ID. We generate unique global IDs for each post and also store them as strings.
 
 Posts in the key-value store will look like this:
 
@@ -86,13 +85,13 @@ Posts in the key-value store will look like this:
 
 Right now the store is empty. Next, define how the user adds a posts.
 
-With the Cosmos SDK, users can interact with your app with either a CLI (`blogd`) or by sending HTTP requests. Let's define the CLI command first. Users should be able to type `blogd tx blog create-post 'This is a post!' 'Welcome to my blog app.' --from=user1` to add a post to your store. The `create-post` subcommand hasn’t been defined yet--let’s do it now.
+With the Cosmos SDK, users can interact with your app with either a CLI (`blogd`) or by sending HTTP requests. Let's define the CLI command first. Users should be able to type `blogd tx blog create-post 'This is a post!' 'Welcome to my blog app.' --from=alice` to add a post to your store. The `create-post` subcommand hasn’t been defined yet--let’s do it now.
 
 ## Create the CLI Function
 
 Open the CLI transaction file `x/blog/client/cli/tx.go`.
 
-In the `import` block, make sure to import these four packages:
+In the `import` block, make sure to import the following packages:
 
 ```go
 // x/blog/client/cli/tx.go
@@ -104,19 +103,18 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	// "github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/example/blog/x/blog/types"
 )
 ```
 
-This file already contains the function `GetTxCmd` which defines custom `blogd` [commands](https://docs.cosmos.network/master/building-modules/module-interfaces.html#cli). We will add the custom `create-post` command to our `blogd` by first adding `GetCmdCreatePost` to `blogTxCmd`.
+This file already contains the function `GetTxCmd` which defines custom `blogd` [commands](https://docs.cosmos.network/master/building-modules/module-interfaces.html#cli). We will add the custom `create-post` command to our `blogd` by first adding `CmdCreatePost` to `blogTxCmd`.
 
 ```go
-  // this line is used by starport scaffolding # 1
-  cmd.AddCommand(CmdCreatePost())
+	// this line is used by starport scaffolding # 1
+	cmd.AddCommand(CmdCreatePost())
 ```
 
-At the end of the file, let's define `GetCmdCreatePost` itself.
+At the end of the file, let's define `CmdCreatePost` itself.
 
 ```go
 func CmdCreatePost() *cobra.Command {
@@ -125,8 +123,8 @@ func CmdCreatePost() *cobra.Command {
 		Short: "Creates a new post",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-      argsTitle := string(args[0])
-      argsBody := string(args[1])
+			argsTitle := string(args[0])
+			argsBody := string(args[1])
       
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -145,7 +143,6 @@ func CmdCreatePost() *cobra.Command {
 
     return cmd
 }
-
 ```
 
 The function above defines what happens when you run the `create-post` subcommand. `create-post` takes two arguments `[title] [body]`, creates a message `NewMsgCreatePost` (with title as `args[0]` and `args[1]`) and broadcasts this message to be processed in your application.
@@ -174,11 +171,10 @@ Similarly to the post proto, `MsgCreatePost` contains our post definition.
 func NewMsgCreatePost(creator string, title string, body string) *MsgCreatePost {
   return &MsgCreatePost{
 		Creator: creator,
-    Title: title,
-    Body: body,
+		Title: title,
+		Body: body,
 	}
 }
-
 ```
 
 `NewMsgCreatePost` is a constructor function that creates the `MsgCreatePost` message. The following five functions have to be defined to implement the `Msg` interface. They allow you to perform validation that doesn’t require access to the store (like checking for empty values), etc.
@@ -186,36 +182,40 @@ func NewMsgCreatePost(creator string, title string, body string) *MsgCreatePost 
 ```go
 // Route ...
 func (msg MsgCreatePost) Route() string {
-  return RouterKey
+	return RouterKey
 }
+
 // Type ...
 func (msg MsgCreatePost) Type() string {
-  return "CreatePost"
+	return "CreatePost"
 }
+
 // GetSigners ...
 func (msg *MsgCreatePost) GetSigners() []sdk.AccAddress {
-  creator, err := sdk.AccAddressFromBech32(msg.Creator)
-  if err != nil {
-    panic(err)
-  }
-  return []sdk.AccAddress{creator}
+	creator, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{creator}
 }
+
 // GetSignBytes ...
 func (msg *MsgCreatePost) GetSignBytes() []byte {
-  bz := ModuleCdc.MustMarshalJSON(msg)
-  return sdk.MustSortJSON(bz)
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
 }
+
 // ValidateBasic ...
 func (msg *MsgCreatePost) ValidateBasic() error {
-  _, err := sdk.AccAddressFromBech32(msg.Creator)
-  	if err != nil {
+	_, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
   		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
   	}
-  return nil
+	return nil
 }
 ```
 
-Going back to `GetCmdCreatePost` in `x/blog/client/cli/tx.go`, you'll see `MsgCreatePost` being created and broadcast with `GenerateOrBroadcastMsgs`.
+Going back to `CmdCreatePost` in `x/blog/client/cli/tx.go`, you'll see `MsgCreatePost` being created and broadcast with `GenerateOrBroadcastMsgs`.
 
 After being broadcast, the messages are processed by an important part of the application, called [**handlers**](https://docs.cosmos.network/master/building-modules/handler.html).
 
@@ -224,11 +224,13 @@ After being broadcast, the messages are processed by an important part of the ap
 You should already have the function `NewHandler` defined which lists all available handlers. Modify it to include a new function called `handleMsgCreatePost`.
 
 ```go
-	//x/blog/handler.go
-    switch msg := msg.(type) {
-    case *types.MsgCreatePost:
-        return handleMsgCreatePost(ctx, k, msg)
-    default:
+// x/blog/handler.go
+
+		switch msg := msg.(type) {
+		// this line is used by starport scaffolding # 1
+		case *types.MsgCreatePost:
+			return handleMsgCreatePost(ctx, k, msg)
+		default:
 ```
 
 Create the handler in `handler_post.go` file
@@ -334,11 +336,11 @@ func (k Keeper) HasPost(ctx sdk.Context, id string) bool {
 }
 
 func (k Keeper) GetPostOwner(ctx sdk.Context, key string) string {
-    return k.GetPost(ctx, key).Creator
+	return k.GetPost(ctx, key).Creator
 }
 
 func (k Keeper) GetAllPost(ctx sdk.Context) (msgs []types.Post) {
-    store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.PostKey))
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.PostKey))
 	iterator := sdk.KVStorePrefixIterator(store, types.KeyPrefix(types.PostKey))
 
 	defer iterator.Close()
@@ -346,15 +348,14 @@ func (k Keeper) GetAllPost(ctx sdk.Context) (msgs []types.Post) {
 	for ; iterator.Valid(); iterator.Next() {
 		var msg types.Post
 		k.cdc.MustUnmarshalBinaryBare(iterator.Value(), &msg)
-        msgs = append(msgs, msg)
+		msgs = append(msgs, msg)
 	}
 
-    return
+	return
 }
-
 ```
 
-`CreatePost` creates a key by concatenating a post prefix with an ID. If you look back at how our store looks, you’ll notice keys have prefixes, which is why `post-0bae9f7d-20f8-4b51-9d5c-af9103177d66` contained the prefix `post-` . The reason for this is you have one store, but you might want to keep different types of objects in it, like posts and users. Prefixing keys with `post-` and `user-` allows you to share one storage space between different types of objects.
+`CreatePost` creates a key by concatenating a post prefix with an ID. If you look back at how our store looks, you’ll notice keys have prefixes, for example `Post-value-0bae9f7d-20f8-4b51-9d5c-af9103177d66` contains the prefix `Post-value-` . The reason for this is you have one store, but you might want to keep different types of objects in it, like posts and users. Prefixing keys such as `Post-value-` and `User-value-` allows you to share one storage space between different types of objects.
 
 ## Add the Prefix for a Post
 
@@ -366,8 +367,11 @@ package types
 
 const (
 	// Other constants...
-	// PostPrefix is used for keys in the KV store
+
+	// PostKey defines the post value store key
   	PostKey= "Post-value-"
+
+	// PostCountKey defines the post count store key
 	PostCountKey= "Post-count-"
 )
 ```
@@ -383,28 +387,27 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
-    cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-    sdk "github.com/cosmos/cosmos-sdk/types"
+	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	// this line is used by starport scaffolding # 1
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
-    // this line is used by starport scaffolding # 2
-  cdc.RegisterConcrete(&MsgCreatePost{}, "blog/CreatePost", nil)
-
-} 
+	// this line is used by starport scaffolding # 2
+	cdc.RegisterConcrete(&MsgCreatePost{}, "blog/CreatePost", nil)
+}
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
-    // this line is used by starport scaffolding # 3
-  registry.RegisterImplementations((*sdk.Msg)(nil),
-    &MsgCreatePost{},
-  )
+	// this line is used by starport scaffolding # 3
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgCreatePost{},
+	)
 }
 
 var (
-	amino = codec.NewLegacyAmino()
+	amino     = codec.NewLegacyAmino()
 	ModuleCdc = codec.NewAminoCodec(amino)
 )
-
 ```
 
 ## Launch the Application
@@ -439,16 +442,15 @@ BUILD_FLAGS := -ldflags '$(ldflags)'
 all: install
 
 install: go.sum
-		@echo "--> Installing blogd"
-		@go install -mod=readonly $(BUILD_FLAGS) ./cmd/blogd
+	@echo "--> Installing blogd"
+	@go install -mod=readonly $(BUILD_FLAGS) ./cmd/blogd
 
 go.sum: go.mod
-		@echo "--> Ensure dependencies have not been modified"
-		GO111MODULE=on go mod verify
+	@echo "--> Ensure dependencies have not been modified"
+	GO111MODULE=on go mod verify
 
 test:
 	@go test -mod=readonly $(PACKAGES)
-
 ```
 
 
@@ -488,7 +490,7 @@ Congratulations! You have just created and launched your custom blockchain and s
 ### Unknown command "create-post" for "blog"
 
 ```bash
-blogd tx blog create-post 'Hello!' 'My first post' --from=user1
+blogd tx blog create-post 'Hello!' 'My first post' --from=alice
 ERROR: unknown command "create-post" for "blog"
 ```
 
@@ -497,7 +499,7 @@ Make sure you’ve added `cmd.AddCommand(CmdCreatePost())`, to `func GetTxCmd` i
 ### Unrecognized blog message type
 
 ```bash
-blogd tx blog create-post 'Hello!' 'My first post' --from=user1
+blogd tx blog create-post 'Hello!' 'My first post' --from=alice
 ERROR: unrecognized blog message type
 ```
 
@@ -510,7 +512,7 @@ to `func NewHandler` in `x/blog/handler.go`
 ### Cannot encode unregistered concrete type
 
 ```bash
-blogd tx blog create-post Hello! --from=user1
+blogd tx blog create-post Hello! --from=alice
 panic: Cannot encode unregistered concrete type types.MsgCreatePost.
 ```
 

--- a/blog/tutorial/02-cli-list-post.md
+++ b/blog/tutorial/02-cli-list-post.md
@@ -4,7 +4,7 @@ order: 2
 
 # List posts
 
-To list created posts we will be using `blogd query blog list-post` and `blogd query blog get-post` command. `list-post` and `get-post` subcommand hasn’t been defined yet, so let’s do it now. [Query commands](https://docs.cosmos.network/master/building-modules/querier.html) from the CLI are handled by `query.go`.
+To list created posts we will be using `blogd query blog list-post` and `blogd query blog get-post` command. The `list-post` and `get-post` subcommands haven’t been defined yet, so let’s do it now. [Query commands](https://docs.cosmos.network/master/building-modules/querier.html) from the CLI are handled by `query.go`.
 
 First we define our proto files, in `proto/blog`
 
@@ -24,14 +24,13 @@ option go_package = "github.com/example/blog/x/blog/types";
 
 // Query defines the gRPC querier service.
 service Query {
-    // this line is used by starport scaffolding # 2
+	// this line is used by starport scaffolding # 2
 	rpc Post(QueryGetPostRequest) returns (QueryGetPostResponse) {
 		option (google.api.http).get = "/example/blog/blog/post/{id}";
 	}
 	rpc PostAll(QueryAllPostRequest) returns (QueryAllPostResponse) {
 		option (google.api.http).get = "/example/blog/blog/post";
 	}
-
 }
 
 // this line is used by starport scaffolding # 3
@@ -78,12 +77,13 @@ Create the `x/blog/client/cli/queryPost.go` file.
 package cli
 
 import (
-    "context"
+	"context"
+
+	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/spf13/cobra"
-    "github.com/example/blog/x/blog/types"
+	"github.com/example/blog/x/blog/types"
 )
 
 func CmdListPost() *cobra.Command {
@@ -91,34 +91,34 @@ func CmdListPost() *cobra.Command {
 		Use:   "list-post",
 		Short: "list all post",
 		RunE: func(cmd *cobra.Command, args []string) error {
-            clientCtx, err := client.GetClientTxContext(cmd)
-            if err != nil {
-                return err
-            }
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
 
-            pageReq, err := client.ReadPageRequest(cmd.Flags())
-            if err != nil {
-                return err
-            }
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
 
-            queryClient := types.NewQueryClient(clientCtx)
+			queryClient := types.NewQueryClient(clientCtx)
 
-            params := &types.QueryAllPostRequest{
-                Pagination: pageReq,
-            }
+			params := &types.QueryAllPostRequest{
+				Pagination: pageReq,
+			}
 
-            res, err := queryClient.PostAll(context.Background(), params)
-            if err != nil {
-                return err
-            }
+			res, err := queryClient.PostAll(context.Background(), params)
+			if err != nil {
+				return err
+			}
 
-            return clientCtx.PrintProto(res)
+			return clientCtx.PrintProto(res)
 		},
 	}
 
 	flags.AddQueryFlagsToCmd(cmd)
 
-    return cmd
+	return cmd
 }
 
 func CmdShowPost() *cobra.Command {
@@ -127,29 +127,29 @@ func CmdShowPost() *cobra.Command {
 		Short: "shows a post",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-            clientCtx, err := client.GetClientTxContext(cmd)
-            if err != nil {
-                return err
-            }
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
 
-            queryClient := types.NewQueryClient(clientCtx)
+			queryClient := types.NewQueryClient(clientCtx)
 
-            params := &types.QueryGetPostRequest{
-                Id: args[0],
-            }
+			params := &types.QueryGetPostRequest{
+				Id: args[0],
+			}
 
-            res, err := queryClient.Post(context.Background(), params)
-            if err != nil {
-                return err
-            }
+			res, err := queryClient.Post(context.Background(), params)
+			if err != nil {
+				return err
+			}
 
-            return clientCtx.PrintProto(res) 
+			return clientCtx.PrintProto(res) 
 		},
 	}
 
 	flags.AddQueryFlagsToCmd(cmd)
 
-    return cmd
+	return cmd
 }
 ```
 
@@ -176,14 +176,14 @@ const (
 
 ```go
 // x/blog/keeper/query.go
-    switch path[0] {
-    case types.QueryGetPost:
-      return getPost(ctx, path[1], k, legacyQuerierCdc)
 
-    case types.QueryListPost:
-      return listPost(ctx, k, legacyQuerierCdc)
-
-    default:
+		switch path[0] {
+		// this line is used by starport scaffolding # 2
+		case types.QueryGetPost:
+			return getPost(ctx, path[1], k, legacyQuerierCdc)
+		case types.QueryListPost:
+			return listPost(ctx, k, legacyQuerierCdc)
+		default:
 ```
 
 Now define `listPost`:
@@ -225,7 +225,6 @@ func getPost(ctx sdk.Context, id string, keeper Keeper, legacyQuerierCdc *codec.
 
 	return bz, nil
 }
-
 ```
 
 In the keeper we define also the grpc of our queryPost function.
@@ -288,7 +287,6 @@ func (k Keeper) Post(c context.Context, req *types.QueryGetPostRequest) (*types.
 
 	return &types.QueryGetPostResponse{Post: &post}, nil
 }
-
 ```
 
 We add the grpc query handler to our module on 
@@ -310,11 +308,12 @@ Search for the `RegisterGRPCGatewayRoutes` function and add the `RegisterQueryHa
 ```go
 // x/blog/module.go
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-    types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+	// this line is used by starport scaffolding # 2
+	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
 }
 ```
 
-This function uses a prefix iterator to loop through all the keys with a given prefix (in our case `PostPrefix` is `"post-"`). We’re getting values by key with `store.Get` and appending them to `postList`. Finally, we unmarshal bytes back to JSON and return the result to the console.
+This function uses a prefix iterator to loop through all the keys with a given prefix (in our case `PostKey` is `"Post-value-"`). We’re getting values by key with `store.Get` and appending them to `postList`. Finally, we unmarshal bytes back to JSON and return the result to the console.
 
 Now let’s see how it works. Run the following command to recompile your app, clear the data and relaunch the chain:
 
@@ -325,7 +324,7 @@ starport serve
 After the app has launched, open a different terminal window and create a post:
 
 ```sh
-blogd tx blog create-post 'Hello!' 'This is my first blog post.' --from=user1
+blogd tx blog create-post 'Hello!' 'This is my first blog post.' --from=alice
 ```
 
 Now run the query to see the post:
@@ -334,15 +333,12 @@ Now run the query to see the post:
 blogd query blog list-post
 ```
 
-```json
-[
-  {
-    "creator": "cosmos1mc6leyjdwd9ygxeqdnvtsh7ks3knptjf3s5lf9",
-    "title": "Hello!",
-    "body": "This is my first blog post.",
-    "id": "30808a80-799d-475c-9f5d-b382ea24d79c"
-  }
-]
+```
+Post:
+- body: This is my first blog post.
+  creator: cosmos1mc6leyjdwd9ygxeqdnvtsh7ks3knptjf3s5lf9
+  id: "0"
+  title: Hello!
 ```
 
 That’s a newly created post along with your address and a unique ID. Try creating more posts and see the output.

--- a/blog/tutorial/04-starport-user-interface.md
+++ b/blog/tutorial/04-starport-user-interface.md
@@ -12,15 +12,16 @@ After using the mnemonic from the output of `starport serve`, you can use this U
 
 ### Inspect the Frontend
 
-Open the file at `vue/src/views/Index.vue`.
+Open the file at `vue/src/views/Types.vue`.
 
-To see a form for creating `post` items in your app add a `<sp-type-form/>` component:
+To see a form for creating `post` items in your app add a `<SpType ... />` component:
 
 ```vue
-  <div class="sp-container">
-    <!-- sp-sign-in, sp-bank-balances, etc. -->
-    <sp-type-form path="example.blog.blog" type="post" :fields="[ ['creator', 1, 'string'] , ['title', 2, 'string'] , ['body', 3, 'string'] ]" />
-  </div>
+	<div class="sp-container">
+		<!-- this line is used by starport scaffolding # 4 -->
+		<SpType modulePath="example.blog.blog" moduleType="Post" />
+		<SpType modulePath="example.blog.blog" moduleType="Comment" />
+	</div>
 ```
 
 Learn more about available components and cosmos logic that you can use on your `vue` frontend, visit the `@tendermint/vue` library at [github.com/tendermint/vue](https://github.com/tendermint/vue)


### PR DESCRIPTION
This pull request includes minor fixes and formatting for the stargate blog tutorial:

- updates `--from=user1` to `--from=alice`
- updates "three" post properties to "four" post properties
- updates `GetCmdCreatePost` in text to match `CmdCreatePost` in code
- updates `post-` prefix in text to match `Post-value-` prefix in code
- updates expected output for `query blog list-post` from json to plain text
- updates vue component instructions to match latest vue layout
- updates format to consistently use tabs for better readability

