### PR TITLE
Remove v0.39 tutorials from the navbar

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -28,7 +28,7 @@ module.exports = {
       auto: false,
       nav: [
         {
-          title: "v0.40+ Stargate Tutorials",
+          title: "Tutorials",
           children: [
             {
               title: "IBC Hello World",
@@ -53,7 +53,7 @@ module.exports = {
           ],
         },
         {
-          title: "Migrate Cosmos SDK v0.39 to v0.40",
+          title: "Migrate to Stargate",
           children: [
             {
               title: "PoFE Migration",

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -62,41 +62,6 @@ module.exports = {
             },
           ]
         },
-        {
-          title: "v0.39 Tutorials",
-          children: [
-            {
-              title: "Voter",
-              path: "/voter-legacy/",
-              directory: true,
-            },
-            {
-              title: "Blog",
-              path: "/blog-legacy/tutorial/",
-              directory: true,
-            },               
-            {
-              title: "PoFE",
-              path: "/proof-of-file-existence/tutorial/",
-              directory: true,
-            },
-            {
-              title: "Scavenge",
-              path: "/scavenge/tutorial/",
-              directory: true,
-            },
-            {
-              title: "Nameservice",
-              path: "/nameservice/tutorial/",
-              directory: true,
-            },
-            {
-              title: "Cosmos Burner Chain",
-              path: "/burner-chain/",
-              directory: true,
-            },
-          ]
-        }
       ],
     },
     gutter: {


### PR DESCRIPTION
Developers using the tutorials should work with Stargate version v0.40 plus of the Cosmos SDK.