### PR TITLE
Mention that `MsgCreatePost` will be autogenerated

### DIFF
--- a/blog/tutorial/01-index.md
+++ b/blog/tutorial/01-index.md
@@ -174,7 +174,7 @@ import (
 var _ sdk.Msg = &MsgCreatePost{}
 ```
 
-Similarly to the post proto, `MsgCreatePost` contains the post definition.
+Similarly to the post proto, `MsgCreatePost` contains the post definition. `MsgCreatePost` will be automatically generated when you launch the application, so don't worry about errors if you see any.
 
 ```go
 func NewMsgCreatePost(creator string, title string, body string) *MsgCreatePost {


### PR DESCRIPTION
Currently without knowing that running `starport chain serve` will generate the `MsgCreatePost` definition, it seems like it is missing information and may cause confusion if the user has their editor show errors as they follow the tutorial.