### PR TITLE
docs: add authz module tutorial

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -105,6 +105,11 @@ module.exports = {
               directory: true,
             },
             {
+              title: "Understand the Authz Module",
+              path: "authz-module/",
+              directory: true,
+            },
+            {
               title: "Deploy Your Blockchain on Digital Ocean",
               path: "/publish-app-do/",
               directory: true,
@@ -256,6 +261,7 @@ module.exports = {
     "blog/tutorial/*.md",
     "interchain-exchange/tutorial/*.md",
     "liquidity-module/*.md",
+    "authz-module/*.md",
     "publish-app-do/*.md",
     "starport/*.md",
     "understanding-ibc-denoms/*.md",

--- a/authz-module/index.md
+++ b/authz-module/index.md
@@ -1,0 +1,20 @@
+---
+parent:
+  title: Understanding the Authz Module
+order: 0
+description: Use the Cosmos SDK authz module to grant authorizations from one account (the granter) to another account (the grantee).
+---
+
+# Authz Module
+
+The authz ("authorization") module enables a granter to grant authorizations to a grantee that allows the grantee to execute messages on behalf of the granter.
+
+## Use Authz to Grant Authorizations
+
+By implementing the [authz module](https://docs.cosmos.network/v0.43/modules/authz/), Cosmos SDK application developers give users the ability to grant certain privelages to other users. For example, a user may want another user to vote on their behalf. Rather than giving the other user access to their account, the user can grant an authorization that allows the other user to execute the `MsgVote` message on their behalf.
+
+How users decide to use the authz module is up to them. In some cases, a user may want to create a root account that acts as a secure bank and then create another account that has limited capabilities, such as voting. The authz module can also be used to distribute authorizations to different members of a DAO. The root account could be a multisig account and certain authorizations could be granted to members that would allow those members to execute messages without requiring signatures from all members of the DAO.
+
+In this tutorial, you spin up a single node network using the simulation application in Cosmos SDK (`simapp`), grant an authorization to another account, and then execute a message on behalf of the granter as the grantee.
+
+...


### PR DESCRIPTION
Closes: https://github.com/cosmos/advocates/issues/22

This pull request adds an authz module tutorial.

> In this tutorial, you spin up a single node network using the simulation application in Cosmos SDK (`simapp`), grant an authorization to another account, and then execute a message on behalf of the granter as the grantee.