### PR TITLE
docs: Module 3 Multistore & Keepers (B9lab updates 2-3)

### DIFF
--- a/b9lab-content/3-main-concepts/10-multistore-keepers.md
+++ b/b9lab-content/3-main-concepts/10-multistore-keepers.md
@@ -109,7 +109,7 @@ Each tree version is immutable and can be retrieved even after a commit, dependi
 
 ## Additional KVStore wrappers
 
-<!-- Add an introductory sentence before the next headline level -->
+Beside the above store types, there are a few others with more specific usage.
 
 ### GasKv Store
 


### PR DESCRIPTION
Docs content update for Module 3 (Main Concepts), Section _Multistore & Keepers_ - part of the [b9lab-content](https://github.com/cosmos/sdk-tutorials/tree/master/b9lab-content).

### Content state

**✔️ Completed**

### Technical review

- [x] requested
- [x] completed

### Language review

- [x] requested
- [ ] completed
