### PR TITLE
Update Starport install URL

### DIFF
--- a/hello-world/tutorial/index.md
+++ b/hello-world/tutorial/index.md
@@ -51,7 +51,7 @@ When the installation succeeds, you see this message:
 Installed at /usr/local/bin/starport
 ```
 
-You can use Starport in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.16.2), but this tutorial assumes you are using a local Starport installation. See [Install Starport](https://docs.starport.network/intro/install.html).
+You can use Starport in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.16.2), but this tutorial assumes you are using a local Starport installation. See [Install Starport](https://docs.starport.network/guide/install.html).
 
 ## Create a Blockchain App
 

--- a/interchain-exchange/tutorial/02-app-init.md
+++ b/interchain-exchange/tutorial/02-app-init.md
@@ -16,7 +16,7 @@ To install `starport` into `/usr/local/bin`, run the following command:
 curl https://get.starport.network/starport@v0.16.2! | bash
 ```
 
-You can also use Starport v0.16.2 in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.16.2), but this tutorial assumes you are using a local Starport installation. For more installation options, see [install Starport](https://docs.starport.network/intro/install.html).
+You can also use Starport v0.16.2 in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.16.2), but this tutorial assumes you are using a local Starport installation. For more installation options, see [install Starport](https://docs.starport.network/guide/install.html).
 
 ## Create the Blockchain
 

--- a/scavenge/tutorial/03-scaffolding.md
+++ b/scavenge/tutorial/03-scaffolding.md
@@ -4,7 +4,7 @@ order: 3
 
 # Scaffolding
 
-We'll be using a CLI tool called [Starport](https://github.com/tendermint/starport) to create a new Cosmos SDK blockchain. To use `starport` [install it](https://docs.starport.network/intro/install.html) on your local machine:
+We'll be using a CLI tool called [Starport](https://github.com/tendermint/starport) to create a new Cosmos SDK blockchain. To use `starport` [install it](https://docs.starport.network/guide/install.html) on your local machine:
 
 ```bash
 curl https://get.starport.network/starport@v0.17.0! | bash

--- a/starport/index.md
+++ b/starport/index.md
@@ -15,7 +15,7 @@ The Starport tool is the easiest way to build a blockchain and accelerate chain 
 
 ## Upgrading Your Starport Installation
 
-To upgrade your Starport installation, see [Install Starport](https://docs.starport.network/intro/install.html).
+To upgrade your Starport installation, see [Install Starport](https://docs.starport.network/guide/install.html).
 
 ## Install a Specific Version of Starport
 

--- a/voter/index.md
+++ b/voter/index.md
@@ -42,7 +42,7 @@ When the installation succeeds, you see this message:
 Installed at /usr/local/bin/starport
 ```
 
-You can use Starport in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.17.0), but this tutorial assumes you are using a local Starport installation. See [Install Starport](https://docs.starport.network/intro/install.html).
+You can use Starport in a [browser-based IDE](http://gitpod.io/#https://github.com/tendermint/starport/tree/v0.17.0), but this tutorial assumes you are using a local Starport installation. See [Install Starport](https://docs.starport.network/guide/install.html).
 
 ## Voting App Goals
 


### PR DESCRIPTION
The URL is now https://docs.starport.network/guide/install.html