### PR TITLE
Seeds are not connecting

### DIFF
--- a/connecting-to-testnet/building-binary.md
+++ b/connecting-to-testnet/building-binary.md
@@ -49,6 +49,7 @@ where `YOUR_MONIKER` is a placeholder for a string that identifies your node. Be
     ```
 
 1. Add seed nodes using the command that is suitable for your environment.
+//seeds are not connecting
 
     - For operating systems other than macOS:
 


### PR DESCRIPTION
Whenever I try to run the testnet using the above-mentioned steps an error shows up
ERR Error dialing seed err="dial tcp 34.139.180.212:31729: connect: connection refused" module=p2p seed={"id":"e6fab0296c0cc31228756822b15e98cfa84ff97b","ip":"34.139.180.212","port":31729}
ERR Error dialing seed err="dial tcp 34.139.133.217:32073: connect: connection refused" module=p2p seed={"id":"64fefc98915aa430417ba893bf13bd8cc101aedf","ip":"34.139.133.217","port":32073}
ERR Couldn't connect to any seeds module=p2p