### PR TITLE
docs: Module 3 Protobuf - code sample integration (B9lab updates 2-2-a)

### DIFF
--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -2,39 +2,43 @@
 
 ## Overview
 
-Protocol buffers, also called Protobuf in the short form, are an open source, extensible,  cross-platform and language-neutral method of serializing object data, primarily for network communication. Libraries for multiple platforms parse a common interface description language to generate source code for encoding and decoding streams of bytes representing structured data. 
+Protocol buffers, also called Protobuf in the short form, are an open source, extensible,  cross-platform and language-neutral method of serializing object data, primarily for network communication. Libraries for multiple platforms parse a common interface description language to generate source code for encoding and decoding streams of bytes representing structured data.
 
-Originally designed and developed by Google, Protobuf has been an open source project since 2008 and services as the basis for Remote Procedure Call (RPC) systems. 
+Originally designed and developed by Google, Protobuf has been an open source project since 2008 and services as the basis for Remote Procedure Call (RPC) systems.
 
 `.proto` files contain data structures called messages. A compiler, `protoc`, interprets the `.proto` file and generates source code in supported languages,  C++, C#, Dart, Go, Java and Python.
 
 <HighlightBox type=”info”>
-Google provides the [gRPC project](https://blog.conan.io/2019/03/06/Serializing-your-data-with-Protobuf.html), a universalRPC framework, that supports Protobuf directly. See the section entitled Compiler Invocation for more information about the process.
+
+Google provides the [gRPC project](https://blog.conan.io/2019/03/06/Serializing-your-data-with-Protobuf.html), a universal RPC framework, that supports Protobuf directly. See the section entitled Compiler Invocation for more information about the process.
+
 </HighlightBox>
 
 ### Working with Protocol Buffers
 
-Define a data structure in a `.proto` file. This is a normal text file with descriptive syntax. Data is represented as a message containing name-value pairs called fields. 
-Compile your Protobuf Schema. `.protoc` generates data access classes with accessors for each field in your preferred language according to command-line options. Accessors include serializing, deserializing and parsing. 
+Define a data structure in a `.proto` file. This is a normal text file with descriptive syntax. Data is represented as a message containing name-value pairs called fields.
+Compile your Protobuf Schema. `.protoc` generates data access classes with accessors for each field in your preferred language according to command-line options. Accessors include serializing, deserializing and parsing.
 
 ## Protobuf Basics for Go
 
-The [gobs](https://golang.org/pkg/encoding/gob/) package for Go is a comprehensive package for the Go environment but it doesn’t work well if you need to share information with applications written in other languages. Another challenge is how to contend with fields that may themselves contain information that needs to be parsed or encoded. 
+The [gobs](https://golang.org/pkg/encoding/gob/) package for Go is a comprehensive package for the Go environment but it doesn’t work well if you need to share information with applications written in other languages. Another challenge is how to contend with fields that may themselves contain information that needs to be parsed or encoded.
 
-For example, a JSON or XML object may contain discrete fields that are stored in a string field. In another example, a time may be stored as two integers representing hour and minute. A Protobuf encapsulated the necessary conversions in both directions. The generated classes provides getters and setters for the fields and takes care of the details of reading and writing the message as a unit. Importantly, the Protobuf format supports extending the format over time in a way that code can still read data encoded in the old format. 
+For example, a JSON or XML object may contain discrete fields that are stored in a string field. In another example, a time may be stored as two integers representing hour and minute. A Protobuf encapsulated the necessary conversions in both directions. The generated classes provides getters and setters for the fields and takes care of the details of reading and writing the message as a unit. Importantly, the Protobuf format supports extending the format over time in a way that code can still read data encoded in the old format.
 
-Go developers access the setters and getters in the generated source code through the Go Protobuf API. 
+Go developers access the setters and getters in the generated source code through the Go Protobuf API.
 
 <HighlightBox type=”info”>
-For more on encoding in Cosmos: https://docs.cosmos.network/master/core/encoding.html 
-Protobuf documentation overview: https://docs.cosmos.network/master/core/proto-docs.html 
+
+For more on encoding in Cosmos: https://docs.cosmos.network/master/core/encoding.html
+Protobuf documentation overview: https://docs.cosmos.network/master/core/proto-docs.html
+
 </HighlightBox>
 
 ## gRPC
 
-gRPC can use Protobuf as both its Interface Definition Language and as its underlying message interchange format. With gRPC, a client can directly call a method on a server application on a different machine as if it were a local object. 
+gRPC can use Protobuf as both its Interface Definition Language and as its underlying message interchange format. With gRPC, a client can directly call a method on a server application on a different machine as if it were a local object.
 
-gRPC is based on the idea of defining a service and specifying the methods that can be called remotely with their parameters and return types. 
+gRPC is based on the idea of defining a service and specifying the methods that can be called remotely with their parameters and return types.
 
 * **Server side**:  The server implements this interface and runs a gRPC server to handle client calls
 * **Client side**: The client has a stub (referred to as just a client in some languages) that provides the same methods as the server.
@@ -45,7 +49,7 @@ The latest Google APIs will have gRPC versions of their interfaces, letting you 
 
 ## Types
 
-The core of a Cosmos SDK application mainly consists of Type Definitions and Constructor Functions. Defined in `app.go` the type definition of a custom application is simply a struct comprised of the following:
+The core of a Cosmos SDK application mainly consists of type definitions and constructor functions. Defined in `app.go` the type definition of a custom application is simply a `struct` comprised of the following:
 
 * Reference to **baseapp**: A reference to the baseapp defines a custom app type embedding baseapp for your application. In other words, the reference to baseapp allows the custom application to inherit most of baseapp's core logic such as ABCI methods and routing logic.
 * List of **Store Keys**: Each module in the Cosmos SDK uses multistore to persist their part of the state. Access to such stores requires a list of keys that are declared in the type definition of the app.
@@ -53,10 +57,73 @@ The core of a Cosmos SDK application mainly consists of Type Definitions and Con
 * Reference to **codec**: Defaulted to go-amino, the codec in your Cosmos SDK application can be substituted with other suitable encoding frameworks as long as they persist data stores in byte slices and are deterministic.
 Reference to Module Manager: A reference to an object containing a list of the applications modules, known as the Module Manager.
 
-## Long-running exercise
+<ExpansionPanel title="Show me some code for my checkers blockchain">
 
-We have defined a number of data types: our transactions and our `FullGame`. Perhaps it is time to define them in Protobuf so as to enjoy its serialization facilities.
+In the previous code samples, you saw something like:
 
-We try to reuse the pre-existing `Game` if possible. Otherwise, we provide a transformer so as to reuse the rules code.
+```go
+type StoredGame struct {
+    Creator string
+    Index string // The unique id that identifies this game.
+    Game string // The serialized board.
+    Turn string // "red" or "black"
+    Red string
+    Black string
+    Wager uint64
+}
+```
+With a _helpful_ note telling you that you still need to add serialization information like:
 
-<!-- TODO code detail. -->
+```go
+type StoredGame struct {
+    Creator string `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
+    ...
+}
+```
+How are you to add such cryptic commands without any error?
+
+## Move Upstream
+
+This is where Protobuf comes in to simplify your life yet more. The same `StoredGame` can in fact be declared as:
+
+```protobuf
+message StoredGame {
+  string creator = 1;
+  string index = 2;
+  string game = 3;
+  string turn = 4;
+  string red = 5;
+  string black = 6;
+  uint64 wager = 7;
+}
+```
+The `= 1` parts indicate how each field is identified in the serialized output, and additionally provides backward compatibility. Down the road, to preserve backward compatibility, if you add or remove fields, make sure to not reuse numbers for new fields, but to keep increasing the `= x` value.
+
+When _compiling_ it, Protobuf will add the `protobuf:"bytes..."` elements. Similarly, the messages to create a game can be declared in Protobuf as:
+
+```protobuf
+message MsgCreateGame {
+  string creator = 1;
+  string red = 2;
+  string black = 3;
+  uint64 wager = 4;
+}
+
+message MsgCreateGameResponse {
+  string idValue = 1;
+}
+```
+
+## Enter Starport
+
+Can this too be created for you? Yes. If you use Starport and commands like:
+
+```sh
+$ starport scaffold map storedGame game turn red black wager:uint --module checkers --no-message
+$ starport scaffold message createGame red black wager:uint --module checkers --response idValue
+```
+Head to [how to build your own chain](../5-my-own-chain/01-index) for more details on using Starport.
+
+When Starport creates a message for you, it also creates the gRPC definitions and Go handling code.
+
+</ExpansionPanel>

--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -16,8 +16,8 @@ Google provides the [gRPC project](https://blog.conan.io/2019/03/06/Serializing-
 
 ### Working with Protocol Buffers
 
-Define a data structure in a `.proto` file. This is a normal text file with descriptive syntax. Data is represented as a message containing name-value pairs called fields.
-Compile your Protobuf Schema. `.protoc` generates data access classes with accessors for each field in your preferred language according to command-line options. Accessors include serializing, deserializing and parsing.
+The `.proto` file is used to define a data structure. This is a normal text file with descriptive syntax. Data is represented as a message containing name-value pairs called fields.
+To compile your Protobuf Schema, the `.protoc` file generates data access classes with accessors for each field in your preferred language according to command-line options. Accessors include serializing, deserializing and parsing.
 
 ## Protobuf Basics for Go
 

--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -55,7 +55,7 @@ The core of a Cosmos SDK application mainly consists of type definitions and con
 * List of **Store Keys**: Each module in the Cosmos SDK uses multistore to persist their part of the state. Access to such stores requires a list of keys that are declared in the type definition of the app.
 * List of each module’s **Keepers**: A Keeper is an abstract piece in each module to handle the module's interaction with stores, specify references to other modules' keepers, and implement other core functionalities of the module. For cross-module interactions to work, all modules in the Cosmos SDK need to have their keepers declared in the app's type definition and exported as interfaces to other modules so that the keeper's methods of one module can be called and accessed in other modules, when authorized.
 * Reference to **codec**: Defaulted to go-amino, the codec in your Cosmos SDK application can be substituted with other suitable encoding frameworks as long as they persist data stores in byte slices and are deterministic.
-Reference to Module Manager: A reference to an object containing a list of the applications modules, known as the Module Manager.
+* Reference to Module Manager: A reference to an object containing a list of the applications modules, known as the Module Manager.
 
 <ExpansionPanel title="Show me some code for my checkers blockchain">
 

--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -10,7 +10,7 @@ Originally designed and developed by Google, Protobuf has been an open source pr
 
 <HighlightBox type=”info”>
 
-Google provides the [gRPC project](https://blog.conan.io/2019/03/06/Serializing-your-data-with-Protobuf.html), a universal RPC framework, that supports Protobuf directly. See the section entitled Compiler Invocation for more information about the process.
+Google provides the [gRPC project](https://blog.conan.io/2019/03/06/Serializing-your-data-with-Protobuf.html), a universal RPC framework that supports Protobuf directly. See the section titled [Compiler Invocation](https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#invocation) for more information about this process.
 
 </HighlightBox>
 

--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -4,7 +4,7 @@
 
 Protocol buffers, also called Protobuf in the short form, are an open source, extensible, cross-platform and language-neutral method of serializing object data, primarily used for network communication. There are several libraries for multiple platforms that all use a common interface description language to generate source code for encoding and decoding streams of bytes representing structured data.
 
-Originally designed and developed by Google, Protobuf has been an open source project since 2008 and services as the basis for Remote Procedure Call (RPC) systems.
+Originally designed and developed by Google, Protobuf has been an open source project since 2008 and serves as the basis for Remote Procedure Call (RPC) systems.
 
 `.proto` files contain data structures called messages. A compiler, `protoc`, interprets the `.proto` file and generates source code in supported languages, such as Go, C++, C#, Dart, Java, Python, and others.
 
@@ -21,9 +21,9 @@ To compile your Protobuf Schema, the `.protoc` file generates data access classe
 
 ## Protobuf Basics for Go
 
-The [gobs](https://golang.org/pkg/encoding/gob/) package for Go is a comprehensive package for the Go environment but it doesn’t work well if you need to share information with applications written in other languages. Another challenge is how to contend with fields that may themselves contain information that needs to be parsed or encoded.
+The [gobs](https://golang.org/pkg/encoding/gob/) package for Go is a comprehensive package for the Go environment but it doesn't work well if you need to share information with applications written in other languages. Another challenge is how to contend with fields that may themselves contain information that needs to be parsed or encoded.
 
-For example, a JSON or XML object may contain discrete fields that are stored in a string field. In another example, a time may be stored as two integers representing hour and minute. A Protobuf encapsulated the necessary conversions in both directions. The generated classes provides getters and setters for the fields and takes care of the details of reading and writing the message as a unit. Importantly, the Protobuf format supports extending the format over time in a way that code can still read data encoded in the old format.
+For example, a JSON or XML object may contain discrete fields that are stored in a string field. In another example, a time may be stored as two integers representing hour and minute. A Protobuf encapsulates the necessary conversions in both directions. The generated classes provide getters and setters for the fields and take care of the details of reading and writing the message as a unit. Importantly, the Protobuf format supports extending the format over time in a way that code can still read data encoded in the old format.
 
 Go developers access the setters and getters in the generated source code through the Go Protobuf API.
 
@@ -40,10 +40,10 @@ gRPC can use Protobuf as both its Interface Definition Language and as its under
 
 gRPC is based on the idea of defining a service and specifying the methods that can be called remotely with their parameters and return types.
 
-* **Server side**:  The server implements this interface and runs a gRPC server to handle client calls
+* **Server side**: The server implements this interface and runs a gRPC server to handle client calls.
 * **Client side**: The client has a stub (referred to as just a client in some languages) that provides the same methods as the server.
 
-gRPC clients and servers can run and talk to each other in a variety of environments - from servers inside Google to your own desktop - and can be written in any of gRPC’s supported languages. So, for example, you can easily create a gRPC server in Java with clients in Go, Python, or Ruby.
+gRPC clients and servers can run and talk to each other in a variety of environments - from servers inside Google to your own desktop - and can be written in any of gRPC's supported languages. So, for example, you can easily create a gRPC server in Java with clients in Go, Python, or Ruby.
 
 The latest Google APIs will have gRPC versions of their interfaces, letting you easily build Google functionality into your applications.
 
@@ -52,8 +52,8 @@ The latest Google APIs will have gRPC versions of their interfaces, letting you 
 The core of a Cosmos SDK application mainly consists of type definitions and constructor functions. Defined in `app.go` the type definition of a custom application is simply a `struct` comprised of the following:
 
 * Reference to **baseapp**: A reference to the baseapp defines a custom app type embedding baseapp for your application. In other words, the reference to baseapp allows the custom application to inherit most of baseapp's core logic such as ABCI methods and routing logic.
-* List of **Store Keys**: Each module in the Cosmos SDK uses multistore to persist their part of the state. Access to such stores requires a list of keys that are declared in the type definition of the app.
-* List of each module’s **Keepers**: A Keeper is an abstract piece in each module to handle the module's interaction with stores, specify references to other modules' keepers, and implement other core functionalities of the module. For cross-module interactions to work, all modules in the Cosmos SDK need to have their keepers declared in the app's type definition and exported as interfaces to other modules so that the keeper's methods of one module can be called and accessed in other modules, when authorized.
+* List of **Store Keys**: Each module in the Cosmos SDK uses a multistore to persist their part of the state. Access to such stores requires a list of keys that are declared in the type definition of the app.
+* List of each module's **Keepers**: A Keeper is an abstract piece in each module to handle the module's interaction with stores, specify references to other modules' keepers, and implement other core functionalities of the module. For cross-module interactions to work, all modules in the Cosmos SDK need to have their keepers declared in the app's type definition and exported as interfaces to other modules so that the keeper's methods of one module can be called and accessed in other modules, when authorized.
 * Reference to **codec**: Defaulted to go-amino, the codec in your Cosmos SDK application can be substituted with other suitable encoding frameworks as long as they persist data stores in byte slices and are deterministic.
 * Reference to Module Manager: A reference to an object containing a list of the applications modules, known as the Module Manager.
 
@@ -116,7 +116,7 @@ message MsgCreateGameResponse {
 
 ## Enter Starport
 
-When Starport creates a message for you, it also creates the gRPC definitions and Go handling code. Using commands, like the ones below, is relatively easy to achieve for your own chain:
+When Starport creates a message for you, it also creates the gRPC definitions and Go handling code. Using commands like the ones below, makes it relatively easy to introduce Protobuf elements into your own chain:
 
 ```sh
 $ starport scaffold map storedGame game turn red black wager:uint --module checkers --no-message

--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -84,7 +84,7 @@ How are you to add such cryptic commands without any error?
 
 ## Move Upstream
 
-This is where Protobuf comes in to simplify your life yet more. The same `StoredGame` can in fact be declared as:
+This is where Protobuf comes in to simplify your life even more. The same `StoredGame` can in fact be declared as:
 
 ```protobuf
 message StoredGame {

--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -122,8 +122,7 @@ When Starport creates a message for you, it also creates the gRPC definitions an
 $ starport scaffold map storedGame game turn red black wager:uint --module checkers --no-message
 $ starport scaffold message createGame red black wager:uint --module checkers --response idValue
 ```
-Head to [how to build your own chain](../5-my-own-chain/01-index) for more details on using Starport.
 
-When Starport creates a message for you, it also creates the gRPC definitions and Go handling code.
+If you want to dive straight into coding your own chain, head to [how to build your own chain](../5-my-own-chain/01-index) for more details on using Starport.
 
 </ExpansionPanel>

--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -116,7 +116,7 @@ message MsgCreateGameResponse {
 
 ## Enter Starport
 
-Can this too be created for you? Yes. If you use Starport and commands like:
+When Starport creates a message for you, it also creates the gRPC definitions and Go handling code. Using commands, like the ones below, is relatively easy to achieve for your own chain:
 
 ```sh
 $ starport scaffold map storedGame game turn red black wager:uint --module checkers --no-message

--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -6,7 +6,7 @@ Protocol buffers, also called Protobuf in the short form, are an open source, ex
 
 Originally designed and developed by Google, Protobuf has been an open source project since 2008 and services as the basis for Remote Procedure Call (RPC) systems.
 
-`.proto` files contain data structures called messages. A compiler, `protoc`, interprets the `.proto` file and generates source code in supported languages,  C++, C#, Dart, Go, Java and Python.
+`.proto` files contain data structures called messages. A compiler, `protoc`, interprets the `.proto` file and generates source code in supported languages, such as Go, C++, C#, Dart, Java, Python, and others.
 
 <HighlightBox type=”info”>
 

--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -2,15 +2,15 @@
 
 ## Overview
 
-Protocol buffers, also called Protobuf in the short form, are an open source, extensible, cross-platform and language-neutral method of serializing object data, primarily used for network communication. There are several libraries for multiple platforms that all use a common interface description language to generate source code for encoding and decoding streams of bytes representing structured data.
+Protocol buffers, also called Protobuf in the short form, are an open-source, extensible, cross-platform, and language-neutral method of serializing object data, primarily used for network communication. There are several libraries for multiple platforms that all use a common interface description language to generate source code for encoding and decoding streams of bytes representing structured data.
 
-Originally designed and developed by Google, Protobuf has been an open source project since 2008 and serves as the basis for Remote Procedure Call (RPC) systems.
+Originally designed and developed by Google, Protobuf has been an open-source project since 2008 and serves as the basis for Remote Procedure Call (RPC) systems.
 
 `.proto` files contain data structures called messages. A compiler, `protoc`, interprets the `.proto` file and generates source code in supported languages, such as Go, C++, C#, Dart, Java, Python, and others.
 
 <HighlightBox type=”info”>
 
-Google provides the [gRPC project](https://blog.conan.io/2019/03/06/Serializing-your-data-with-Protobuf.html), a universal RPC framework that supports Protobuf directly. See the section titled [Compiler Invocation](https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#invocation) for more information about this process.
+Google provides the [gRPC project](https://blog.conan.io/2019/03/06/Serializing-your-data-with-Protobuf.html), a universal RPC framework that supports Protobuf directly. See the section titled [Compiler Invocation](https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#invocation) for more information on this process.
 
 </HighlightBox>
 
@@ -29,8 +29,9 @@ Go developers access the setters and getters in the generated source code throug
 
 <HighlightBox type=”info”>
 
-For more on encoding in Cosmos: https://docs.cosmos.network/master/core/encoding.html
-Protobuf documentation overview: https://docs.cosmos.network/master/core/proto-docs.html
+For more on encoding in Cosmos, take a peek at [the Cosmos SDK documentation on encoding](https://docs.cosmos.network/master/core/encoding.html).
+
+Here you can find the [Protobuf documentation overview](https://docs.cosmos.network/master/core/proto-docs.html).
 
 </HighlightBox>
 
@@ -57,7 +58,7 @@ The core of a Cosmos SDK application mainly consists of type definitions and con
 * Reference to **codec**: Defaulted to go-amino, the codec in your Cosmos SDK application can be substituted with other suitable encoding frameworks as long as they persist data stores in byte slices and are deterministic.
 * Reference to Module Manager: A reference to an object containing a list of the applications modules, known as the Module Manager.
 
-<ExpansionPanel title="Show me some code for my checkers blockchain">
+<ExpansionPanel title="Show me some code for my checker's blockchain">
 
 In the previous code samples, you saw something like:
 
@@ -72,7 +73,7 @@ type StoredGame struct {
     Wager uint64
 }
 ```
-With a _helpful_ note telling you that you still need to add serialization information like:
+With a _helpful_ note telling you that you still need to add serialization information, like:
 
 ```go
 type StoredGame struct {
@@ -82,7 +83,7 @@ type StoredGame struct {
 ```
 How are you to add such cryptic commands without any error?
 
-## Move Upstream
+## Move upstream
 
 This is where Protobuf comes in to simplify your life even more. The same `StoredGame` can in fact be declared as:
 
@@ -97,9 +98,9 @@ message StoredGame {
   uint64 wager = 7;
 }
 ```
-The `= 1` parts indicate how each field is identified in the serialized output, and additionally provides backward compatibility. As your application upgrades to newer versions, make sure to not reuse numbers for new fields, but to keep increasing the `= x` value to preserve backward compatibility.
+The `= 1` parts indicate how each field is identified in the serialized output and additionally, provides backward compatibility. As your application upgrades to newer versions, make sure to not reuse numbers for new fields but to keep increasing the `= x` value to preserve backward compatibility.
 
-When _compiling_ it, Protobuf will add the `protobuf:"bytes..."` elements. Similarly, the messages to create a game can be declared in Protobuf as:
+When _compiling_, Protobuf will add the `protobuf:"bytes..."` elements. Similarly, the messages to create a game can be declared in Protobuf as:
 
 ```protobuf
 message MsgCreateGame {
@@ -116,13 +117,16 @@ message MsgCreateGameResponse {
 
 ## Enter Starport
 
-When Starport creates a message for you, it also creates the gRPC definitions and Go handling code. Using commands like the ones below, makes it relatively easy to introduce Protobuf elements into your own chain:
+When Starport creates a message for you, it also creates the gRPC definitions and Go handling code. Using commands like the ones below makes it relatively easy to introduce Protobuf elements into your chain:
 
 ```sh
 $ starport scaffold map storedGame game turn red black wager:uint --module checkers --no-message
 $ starport scaffold message createGame red black wager:uint --module checkers --response idValue
 ```
+<HighlightBox type="tip">
 
-If you want to dive straight into coding your own chain, head to [how to build your own chain](../5-my-own-chain/01-index) for more details on using Starport.
+If you want to dive straight into coding your chain, head to [My Own Chain](../5-my-own-chain/01-index) for more details on using Starport.
+
+</HighlightBox>
 
 </ExpansionPanel>

--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Protocol buffers, also called Protobuf in the short form, are an open source, extensible,  cross-platform and language-neutral method of serializing object data, primarily for network communication. Libraries for multiple platforms parse a common interface description language to generate source code for encoding and decoding streams of bytes representing structured data.
+Protocol buffers, also called Protobuf in the short form, are an open source, extensible, cross-platform and language-neutral method of serializing object data, primarily used for network communication. There are several libraries for multiple platforms that all use a common interface description language to generate source code for encoding and decoding streams of bytes representing structured data.
 
 Originally designed and developed by Google, Protobuf has been an open source project since 2008 and services as the basis for Remote Procedure Call (RPC) systems.
 

--- a/b9lab-content/3-main-concepts/09-protobuf.md
+++ b/b9lab-content/3-main-concepts/09-protobuf.md
@@ -97,7 +97,7 @@ message StoredGame {
   uint64 wager = 7;
 }
 ```
-The `= 1` parts indicate how each field is identified in the serialized output, and additionally provides backward compatibility. Down the road, to preserve backward compatibility, if you add or remove fields, make sure to not reuse numbers for new fields, but to keep increasing the `= x` value.
+The `= 1` parts indicate how each field is identified in the serialized output, and additionally provides backward compatibility. As your application upgrades to newer versions, make sure to not reuse numbers for new fields, but to keep increasing the `= x` value to preserve backward compatibility.
 
 When _compiling_ it, Protobuf will add the `protobuf:"bytes..."` elements. Similarly, the messages to create a game can be declared in Protobuf as:
 


### PR DESCRIPTION
Docs content update for Module 3, Section _Protobuf_ - part of the [b9lab-content](https://github.com/cosmos/sdk-tutorials/tree/master/b9lab-content).

This PR adds code samples to the content. The code shown here is taken from the [code example repo](https://github.com/cosmos/b9-checkers-academy-draft/) and has been hardly adjusted. The repo has been reviewed so no need to review it here. What we are looking for is to make sure that the introductory texts are not misleading or even downright wrong.

### Content state

**✔️ Completed**

### Technical review
- [x] requested
- [x] completed

### Language review
- [x] requested
- [x] completed
