### PR TITLE
docs: Module 3 Queries, Events - code sample integration (B9lab updates 2-5-a)

### DIFF
--- a/b9lab-content/3-main-concepts/12-queries.md
+++ b/b9lab-content/3-main-concepts/12-queries.md
@@ -105,7 +105,7 @@ So now you are left with filling in the gaps under TODO. Simple:
         Reason:   "ok",
     }, nil
     ```
-Of note is that the player's move will be tested against the latest validated state of the blockchain. It does not test against the intermediate state being calculated when transactions are being delivered. Nor does it test again the potential state that would result from delivering the transactions still in the transaction pool.
+Of note is that the player's move will be tested against the latest validated state of the blockchain. It does not test against the intermediate state being calculated as transactions are being delivered. Nor does it test against the potential state that would result from delivering the transactions still in the transaction pool.
 
 In practice, this means that a player could test their move only if the opponent's move has been included in a block.
 

--- a/b9lab-content/3-main-concepts/12-queries.md
+++ b/b9lab-content/3-main-concepts/12-queries.md
@@ -2,7 +2,7 @@
 
 ### gRPC routing
 
-A query is a request for information made by end-users of an applications through an interface and processed by a full-node. Available information includes:
+A query is a request for information made by end-users of an application through an interface and processed by a full-node. Available information includes:
 
 * Information about the network.
 * Information about the application itself.

--- a/b9lab-content/3-main-concepts/12-queries.md
+++ b/b9lab-content/3-main-concepts/12-queries.md
@@ -4,32 +4,111 @@
 
 A query is a request for information made by end-users of an applications through an interface and processed by a full-node. Available information includes:
 
-* information about the network, 
-* Information about the application itself, and 
-* Information about the application state
+* Information about the network.
+* Information about the application itself.
+* And information about the application state.
 
 Queries do not require consensus to be processed (as they do not trigger state-transitions) and can therefore be fully handled independently by a full node.
 
 <HighlightBox info=”info”>
-Query lifecycles: Creating, handling queries with the CLI, RPC and application query handling.
-https://github.com/cosmos/cosmos-sdk/blob/master/docs/basics/query-lifecycle.md 
+
+[Query lifecycles](https://github.com/cosmos/cosmos-sdk/blob/master/docs/basics/query-lifecycle.md): Creating, handling queries with the CLI, RPC and application query handling.
+
 </HighlightBox>
 
+<ExpansionPanel title="Show me some code for my checkers blockchain">
 
-## Long-running exercise
+If you used Starport, it has already created queries for you, for instance queries to get one stored game or a list of them. However, you still don't have a way to check whether a move will work. It would be wasteful to send a transaction with an invalid move. It is better to catch such a mistake before submitting a transaction. Let's remedy that. You are going to create a query that informs whether a move can be played.
 
-We need to think in terms of what a server system, or a GUI would need:
+Here again Starport can help you with the simple command:
 
-1. A way to load a game by id.
-2. A way to get current game ids by player.
-3. Perhaps a way to get the games timing out soon.
-4. A way to test whether a move will be accepted.
+```sh
+$ starport scaffold query canPlayMove idValue player fromX:uint fromY:uint toX:uint toY:uint --module checkers --response possible:bool
+```
+This creates the query objects:
 
-Point 1 means we need to revisit our storage structure, and keep a list of game ids by player. Probably ordered by id.
+```go
+type QueryCanPlayMoveRequest struct {
+    IdValue string
+    Player  string
+    FromX   uint64
+    FromY   uint64
+    ToX     uint64
+    ToY     uint64
+}
 
-Point 4 assumes that the previous player's move is already confirmed in a block. Questions:
+type QueryCanPlayMoveResponse struct {
+    Possible bool
+    Reason   string // Actually you have to add this one by hand.
+}
+```
+It also created a function that looks familiar to you:
 
-* Is there a way to test a move's validity while the previous player's move is still in the mempool?
-* Is there a way to make sure that if the next player sends their move before the previous one was confirmed, both txs are ordered _properly_?
+```go
+func (k Keeper) CanPlayMove(goCtx context.Context, req *types.QueryCanPlayMoveRequest) (*types.QueryCanPlayMoveResponse, error) {
+    ...
+    // TODO: Process the query
 
-TODO define in code how these queries would be defined and routed.
+    return &types.QueryCanPlayMoveResponse{}, nil
+}
+```
+So now you are left with filling this in. Simply:
+
+1. Is the game finished? Actually, for this one, you ought to add a `Winner` to your `StoredGame` first.
+2. Is it an expected player?
+    ```go
+    var player rules.Player
+    if strings.Compare(rules.RED_PLAYER.Color, req.Player) == 0 {
+        player = rules.RED_PLAYER
+    } else if strings.Compare(rules.BLACK_PLAYER.Color, req.Player) == 0 {
+        player = rules.BLACK_PLAYER
+    } else {
+        return &types.QueryCanPlayMoveResponse{
+                Possible: false,
+                Reason:   "message creator is not a player",
+            }, nil
+    }
+    ```
+3. Is it the player's turn?
+    ```go
+    fullGame := storedGame.ToFullGame()
+        if !fullGame.Game.TurnIs(player) {
+            return &types.QueryCanPlayMoveResponse{
+                Possible: false,
+                Reason:   "player tried to play out of turn",
+            }, nil
+        }
+    ```
+4. Attempt the move in memory, without committing any new state:
+    ```go
+    _, moveErr := fullGame.Game.Move(
+        rules.Pos{
+            X: int(req.FromX),
+            Y: int(req.FromY),
+        },
+        rules.Pos{
+            X: int(req.ToX),
+            Y: int(req.ToY),
+        },
+    )
+    if moveErr != nil {
+        return &types.QueryCanPlayMoveResponse{
+            Possible: false,
+            Reason:   fmt.Sprintf("wrong move", moveErr.Error()),
+        }, nil
+    }
+    ```
+5. If all was ok, tell it:
+    ```go
+    return &types.QueryCanPlayMoveResponse{
+        Possible: true,
+        Reason:   "ok",
+    }, nil
+    ```
+Of note is that the player's move will be tested against the latest validated state of the blockchain. It does not test against the intermediate state being calculated when transactions are being delivered. Nor does it test again the potential state that would result from delivering the transactions still in the transaction pool.
+
+In practice, this means that a player could test their move only if the opponent's move has been included in a block.
+
+Examples of other possible queries. Get a player's games, or the games soon to time out.
+
+</ExpansionPanel>

--- a/b9lab-content/3-main-concepts/12-queries.md
+++ b/b9lab-content/3-main-concepts/12-queries.md
@@ -18,9 +18,9 @@ Queries do not require consensus to be processed (as they do not trigger state-t
 
 <ExpansionPanel title="Show me some code for my checkers blockchain">
 
-If you used Starport, it has already created queries for you, for instance queries to get one stored game or a list of them. However, you still don't have a way to check whether a move will work. It would be wasteful to send a transaction with an invalid move. It is better to catch such a mistake before submitting a transaction. Let's remedy that. You are going to create a query that informs whether a move can be played.
+If you used Starport, it has already created queries for you, such as queries to get one stored game, or a list of them. However, you still don't have a way to check whether a move will work. It would be wasteful to send a transaction with an invalid move. It is better to catch such a mistake before submitting a transaction. Let's fix that. You are going to create a query that informs whether a move can be played.
 
-Here again Starport can help you with the simple command:
+Again, Starport can help you here with a simple command:
 
 ```sh
 $ starport scaffold query canPlayMove idValue player fromX:uint fromY:uint toX:uint toY:uint --module checkers --response possible:bool

--- a/b9lab-content/3-main-concepts/12-queries.md
+++ b/b9lab-content/3-main-concepts/12-queries.md
@@ -52,7 +52,7 @@ func (k Keeper) CanPlayMove(goCtx context.Context, req *types.QueryCanPlayMoveRe
     return &types.QueryCanPlayMoveResponse{}, nil
 }
 ```
-So now you are left with filling this in. Simply:
+So now you are left with filling in the gaps under TODO. Simple:
 
 1. Is the game finished? Actually, for this one, you ought to add a `Winner` to your `StoredGame` first.
 2. Is it an expected player?

--- a/b9lab-content/3-main-concepts/12-queries.md
+++ b/b9lab-content/3-main-concepts/12-queries.md
@@ -12,7 +12,7 @@ Queries do not require consensus to be processed (as they do not trigger state-t
 
 <HighlightBox info=”info”>
 
-[Query lifecycles](https://github.com/cosmos/cosmos-sdk/blob/master/docs/basics/query-lifecycle.md): Creating, handling queries with the CLI, RPC and application query handling.
+To get a clear overview of the query lifecycle, visit the [detailed documentation](https://docs.cosmos.network/master/basics/query-lifecycle.html) and learn how a query is created, handled, and responded to through various means. 
 
 </HighlightBox>
 

--- a/b9lab-content/3-main-concepts/12-queries.md
+++ b/b9lab-content/3-main-concepts/12-queries.md
@@ -98,7 +98,7 @@ So now you are left with filling in the gaps under TODO. Simple:
         }, nil
     }
     ```
-5. If all was ok, tell it:
+5. If all checks passed, return the OK status:
     ```go
     return &types.QueryCanPlayMoveResponse{
         Possible: true,

--- a/b9lab-content/3-main-concepts/12-queries.md
+++ b/b9lab-content/3-main-concepts/12-queries.md
@@ -2,29 +2,30 @@
 
 ### gRPC routing
 
-A query is a request for information made by end-users of an application through an interface and processed by a full-node. Available information includes:
+A query is a request for information made by end-users of an application through an interface and processed by a full node. Available information includes:
 
 * Information about the network.
 * Information about the application itself.
-* And information about the application state.
+* Information about the application state.
 
-Queries do not require consensus to be processed (as they do not trigger state-transitions) and can therefore be fully handled independently by a full node.
+Queries do not require consensus to be processed as they do not trigger state transitions and can, therefore, be fully handled independently by a full node.
 
 <HighlightBox info=”info”>
 
-To get a clear overview of the query lifecycle, visit the [detailed documentation](https://docs.cosmos.network/master/basics/query-lifecycle.html) and learn how a query is created, handled, and responded to through various means.
+To get a clear overview of the query lifecycle, visit the [detailed Cosmos SDK documentation](https://docs.cosmos.network/master/basics/query-lifecycle.html) and learn how a query is created, handled, and responded to through various means.
 
 </HighlightBox>
 
-<ExpansionPanel title="Show me some code for my checkers blockchain">
+<ExpansionPanel title="Show me some code for my checkers' blockchain">
 
-If you used Starport, it has already created queries for you, such as queries to get one stored game, or a list of them. However, you still don't have a way to check whether a move will work. It would be wasteful to send a transaction with an invalid move. It is better to catch such a mistake before submitting a transaction. Let's fix that. You are going to create a query that informs whether a move can be played.
+If you have used Starport so far, it has already created queries for you, such as queries to get one stored game or a list of them. However, you still do not have a way to check whether a move works/is valid. It would be wasteful to send a transaction with an invalid move. It is better to catch such a mistake before submitting a transaction. So, you are going to create a query to know whether a move is valid.
 
 Again, Starport can help you here with a simple command:
 
 ```sh
 $ starport scaffold query canPlayMove idValue player fromX:uint fromY:uint toX:uint toY:uint --module checkers --response possible:bool
 ```
+
 This creates the query objects:
 
 ```go
@@ -39,9 +40,10 @@ type QueryCanPlayMoveRequest struct {
 
 type QueryCanPlayMoveResponse struct {
     Possible bool
-    Reason   string // Actually you have to add this one by hand.
+    Reason   string // Actually, you have to add this one by hand.
 }
 ```
+
 It also created a function that looks familiar to you:
 
 ```go
@@ -52,10 +54,12 @@ func (k Keeper) CanPlayMove(goCtx context.Context, req *types.QueryCanPlayMoveRe
     return &types.QueryCanPlayMoveResponse{}, nil
 }
 ```
-So now you are left with filling in the gaps under TODO. Simple:
 
-1. Is the game finished? Actually, for this one, you ought to add a `Winner` to your `StoredGame` first.
+So now you are left with filling in the gaps under `TODO`. Simply put:
+
+1. Is the game finished? For this one, you ought to add a `Winner` to your `StoredGame` first.
 2. Is it an expected player?
+
     ```go
     var player rules.Player
     if strings.Compare(rules.RED_PLAYER.Color, req.Player) == 0 {
@@ -69,7 +73,9 @@ So now you are left with filling in the gaps under TODO. Simple:
             }, nil
     }
     ```
+
 3. Is it the player's turn?
+
     ```go
     fullGame := storedGame.ToFullGame()
         if !fullGame.Game.TurnIs(player) {
@@ -79,7 +85,9 @@ So now you are left with filling in the gaps under TODO. Simple:
             }, nil
         }
     ```
+
 4. Attempt the move in memory, without committing any new state:
+
     ```go
     _, moveErr := fullGame.Game.Move(
         rules.Pos{
@@ -98,17 +106,20 @@ So now you are left with filling in the gaps under TODO. Simple:
         }, nil
     }
     ```
+
 5. If all checks passed, return the OK status:
+
     ```go
     return &types.QueryCanPlayMoveResponse{
         Possible: true,
         Reason:   "ok",
     }, nil
     ```
-Of note is that the player's move will be tested against the latest validated state of the blockchain. It does not test against the intermediate state being calculated as transactions are being delivered. Nor does it test against the potential state that would result from delivering the transactions still in the transaction pool.
 
-In practice, this means that a player could test their move only once the opponent's move has been included in a previous block. Fortunately, these kind of edge case scenarios won't be common in our checkers game, and we can expect little to no effect on the user experience.
+Note that the player's move will be tested against the latest validated state of the blockchain. It does not test against the intermediate state being calculated as transactions are delivered, nor does it test against the potential state that would result from delivering the transactions still in the transaction pool.
 
-Of course this is not an exhaustive list of potential queries. Some examples of other possible queries would be to get a player's open games, or to get a list of games that are timing out soon. This really depends on the needs of your application and how much functionality you're willing to provide.
+In practice, a player can test their move only once the opponent's move is included in a previous block. Fortunately, these types of edge case scenarios are not common in our checkers game, and we can expect little to no effect on the user experience.
+
+Of course, this is not an exhaustive list of potential queries. Some examples of other possible queries would be to get a player's open games or to get a list of games that are timing out soon. It depends on the needs of your application and how much functionality you willingly provide.
 
 </ExpansionPanel>

--- a/b9lab-content/3-main-concepts/12-queries.md
+++ b/b9lab-content/3-main-concepts/12-queries.md
@@ -107,8 +107,8 @@ So now you are left with filling in the gaps under TODO. Simple:
     ```
 Of note is that the player's move will be tested against the latest validated state of the blockchain. It does not test against the intermediate state being calculated as transactions are being delivered. Nor does it test against the potential state that would result from delivering the transactions still in the transaction pool.
 
-In practice, this means that a player could test their move only if the opponent's move has been included in a block.
+In practice, this means that a player could test their move only once the opponent's move has been included in a previous block. Fortunately, these kind of edge case scenarios won't be common in our checkers game, and we can expect little to no effect on the user experience.
 
-Examples of other possible queries. Get a player's games, or the games soon to time out.
+Of course this is not an exhaustive list of potential queries. Some examples of other possible queries would be to get a player's open games, or a to get a list of games that are timing out soon. This really depends on the needs of your application and how much functionality you're willing to provide.
 
 </ExpansionPanel>

--- a/b9lab-content/3-main-concepts/12-queries.md
+++ b/b9lab-content/3-main-concepts/12-queries.md
@@ -12,7 +12,7 @@ Queries do not require consensus to be processed (as they do not trigger state-t
 
 <HighlightBox info=”info”>
 
-To get a clear overview of the query lifecycle, visit the [detailed documentation](https://docs.cosmos.network/master/basics/query-lifecycle.html) and learn how a query is created, handled, and responded to through various means. 
+To get a clear overview of the query lifecycle, visit the [detailed documentation](https://docs.cosmos.network/master/basics/query-lifecycle.html) and learn how a query is created, handled, and responded to through various means.
 
 </HighlightBox>
 
@@ -109,6 +109,6 @@ Of note is that the player's move will be tested against the latest validated st
 
 In practice, this means that a player could test their move only once the opponent's move has been included in a previous block. Fortunately, these kind of edge case scenarios won't be common in our checkers game, and we can expect little to no effect on the user experience.
 
-Of course this is not an exhaustive list of potential queries. Some examples of other possible queries would be to get a player's open games, or a to get a list of games that are timing out soon. This really depends on the needs of your application and how much functionality you're willing to provide.
+Of course this is not an exhaustive list of potential queries. Some examples of other possible queries would be to get a player's open games, or to get a list of games that are timing out soon. This really depends on the needs of your application and how much functionality you're willing to provide.
 
 </ExpansionPanel>

--- a/b9lab-content/3-main-concepts/13-events.md
+++ b/b9lab-content/3-main-concepts/13-events.md
@@ -7,7 +7,7 @@ In the Cosmos SDK, events are implemented as an alias of the ABCI `event` type i
 Events allow app developers to attach additional information. This means that transactions might be queried using the events:
 
 ```
-// Event allows application developers to attach additional information to
+// Events allows application developers to attach additional information to
 // ResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.
 // Later, transactions may be queried using these events.
 message Event {

--- a/b9lab-content/3-main-concepts/13-events.md
+++ b/b9lab-content/3-main-concepts/13-events.md
@@ -6,8 +6,8 @@ In the Cosmos SDK, events are implemented as an alias of the ABCI `event` type i
 
 Events are objects that allow app developers to package important information about state transitions in an application. Instead of querying, events can be subscribed to using [websockets](https://docs.tendermint.com/master/tendermint-core/subscription.html#subscribing-to-events-via-websocket).
 
-```
-// Events allows application developers to attach additional information to
+```protobuf
+// Events allow application developers to attach additional information to
 // ResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.
 // Later, transactions may be queried using these events.
 message Event {
@@ -23,8 +23,8 @@ message Event {
 
 In the above, two elements stand out:
 
-* A `type` to categorize the Event at a high-level; for example, the Cosmos SDK uses the `message` _type_ to filter events by Msgs.
-* A list of `attributes` are key-value pairs that give more information about the categorized event. For example, for the "message" type, we can filter events by key-value pairs using `message.action={some_action}, message.module={some_module}` or `message.sender={a_sender}`.
+* A `type` to categorize the event at a high-level. For example, the Cosmos SDK uses the `message` _type_ to filter events by `Msg`.
+* A list of `attributes` are key-value pairs that give more information about the categorized event. For example, for the `message` type, we can filter events by key-value pairs using `message.action={some_action}, message.module={some_module}` or `message.sender={a_sender}`.
 
 <HighlightBox type=”info”>
 
@@ -32,7 +32,7 @@ To parse the attribute values as strings, make sure to add `'` (single quotes) a
 
 </HighlightBox>
 
-Events, their type and attributes are defined on a per-module basis in the module's `/types/events.go` file, and are triggered from the module's Protobuf Msg service by using the `EventManager`. Additionally, each module documents its events under `spec/xx_events.md`.
+Events, their type and attributes are defined on a per-module basis in the module's `/types/events.go` file, and are triggered from the module's Protobuf `Msg` service by using the `EventManager`. Additionally, each module documents its events under `spec/xx_events.md`.
 Events are returned to the underlying consensus engine in response to the following ABCI messages:
 
 * `BeginBlock`
@@ -44,47 +44,54 @@ Events are managed by an abstraction called the `EventManager`.
 
 ## EventManager
 
-`EventManager` tracks a list of events for the entire execution flow of a transaction or `BeginBlock`/`EndBlock`. `EventManager` implements a simple wrapper around a slice of `Event` objects that can be emitted from and provides useful methods. The most used method for Cosmos SDK module and application developers is `EmitEvent`.
+For each of the 4 ABCI calls, `CheckTx`, `DeliverTx`, `BeginBlock` and `EndBlock`, the `EventManager` keeps a list of events and delivers it in full as part of the ABCI response. After delivery in an ABCI response, the `EventManager` empties its list of events. In practice, the `EventManager` implements a simple wrapper around a slice of `Event` objects that can be emitted from and provides useful methods. The most often used method for Cosmos SDK module and application developers is `EmitEvent`.
 
 <HighlightBox type=”info”>
 
-Module developers should handle event emission via the `EventManager#EmitEvent` in each message handler and in each `BeginBlock`/`EndBlock` handler, accessed via the `Context`, where event emission generally follows this pattern:
+Module developers should handle event emission via the `EventManager#EmitEvent` in each message handler and in each `BeginBlock` or `EndBlock` handler, accessed via the `Context`, where event emission generally follows this pattern:
 
-```
+```go
 func (em *EventManager) EmitEvent(event Event) {
     em.events = em.events.AppendEvent(event)
 }
 ```
-
 Each module's handler function should also set a new `EventManager` to the context to isolate emitted events per message:
 
-```
+```go
 func NewHandler(keeper Keeper) sdk.Handler {
     return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
         ctx = ctx.WithEventManager(sdk.NewEventManager())
         switch msg := msg.(type) {
-    // event types
+            // event types
+        }
+    ...
+    }
+}
 ```
 
 </HighlightBox>
 
 ## Subscribing to Events
 
-You can use Tendermint's Websocket (opens new window) to subscribe to events by calling the subscribe RPC method.
+You can use Tendermint's Websocket to subscribe to events by calling the subscribe RPC method.
 
 The main `eventCategories` you can subscribe to are:
 
 * **NewBlock**: Contains Events triggered during `BeginBlock` and `EndBlock`.
 * **Tx**: Contains events triggered during `DeliverTx` (i.e. transaction processing).
-* **ValidatorSetUpdates**: Contains validator set updates for the block.
+* **ValidatorSetUpdates**: Contains updates about the set of validators for the block.
 
 <HighlightBox type=”info”>
 
-→ You can find a full list of event categories [here](https://godoc.org/github.com/tendermint/tendermint/types#pkg-constants)
+→ You can find a full list of event categories [here](https://godoc.org/github.com/tendermint/tendermint/types#pkg-constants).
 
 </HighlightBox>
 
-You can filter for event types and attribute values. For example, a transfer transaction triggers an event of type `Transfer` and has `Recipient` and `Sender` as attributes (as defined in the `events.go` file of the bank module.
+You can filter for event types and attribute values. For example, a transfer transaction triggers an event of type `Transfer` and has `Recipient` and `Sender` as attributes, as defined in the `events.go` file of the bank module.
+
+## Next Up
+
+You just learned about events, where they are expected, and how to emit or receive them. Have a look at the code samples below or head next to learn about the `Context` object in the [next section](./14-context).
 
 <ExpansionPanel title="Show me some code for my checkers blockchain">
 

--- a/b9lab-content/3-main-concepts/13-events.md
+++ b/b9lab-content/3-main-concepts/13-events.md
@@ -78,7 +78,7 @@ The main `eventCategories` you can subscribe to are:
 
 <HighlightBox type=”info”>
 
-→ full list of event categories [here](https://godoc.org/github.com/tendermint/tendermint/types#pkg-constants)
+→ You can find a full list of event categories [here](https://godoc.org/github.com/tendermint/tendermint/types#pkg-constants)
 
 </HighlightBox>
 

--- a/b9lab-content/3-main-concepts/13-events.md
+++ b/b9lab-content/3-main-concepts/13-events.md
@@ -2,7 +2,7 @@
 
 An event is an object that contains information about the execution of the application. Events are used by service providers (block explorers, wallets) to track execution of various messages and index transactions.
 
-In Cosmo SDK, events are implemented as an alias of ABCI `event` type in the forms `{eventType}.{attributeKey}={attributeValue}`.
+In the Cosmos SDK, events are implemented as an alias of the ABCI `event` type in the forms `{eventType}.{attributeKey}={attributeValue}`.
 
 Events allow app developers to attach additional information. This means that transactions might be queried using the events:
 

--- a/b9lab-content/3-main-concepts/13-events.md
+++ b/b9lab-content/3-main-concepts/13-events.md
@@ -1,6 +1,6 @@
 # Events
 
-An event is an object that contains information about the execution of the application. Events are used by service providers (block explorers, wallets) to track execution of various messages and index transactions.
+An event is an object that contains information about the execution of the application. Events are used by service providers (block explorers, wallets, and IBC relayers) to track execution of various messages and index transactions.
 
 In the Cosmos SDK, events are implemented as an alias of the ABCI `event` type in the forms `{eventType}.{attributeKey}={attributeValue}`.
 

--- a/b9lab-content/3-main-concepts/13-events.md
+++ b/b9lab-content/3-main-concepts/13-events.md
@@ -73,7 +73,7 @@ func NewHandler(keeper Keeper) sdk.Handler {
 
 ## Subscribing to Events
 
-You can use Tendermint's Websocket to subscribe to events by calling the subscribe RPC method.
+You can use Tendermint's [Websocket](https://docs.tendermint.com/master/tendermint-core/subscription.html#subscribing-to-events-via-websocket) to subscribe to events by calling the `subscribe` RPC method.
 
 The main `eventCategories` you can subscribe to are:
 

--- a/b9lab-content/3-main-concepts/13-events.md
+++ b/b9lab-content/3-main-concepts/13-events.md
@@ -1,10 +1,10 @@
 # Events
 
-An event is an object that contains information about the execution of the application. Events are used by service providers (block explorers, wallets, and IBC relayers) to track execution of various messages and index transactions.
+An event is an object containing information about the execution of the application. Events are used by service providers (block explorers, wallets, and IBC relayers) to track the execution of various messages and index transactions.
 
-In the Cosmos SDK, events are implemented as an alias of the ABCI `event` type in the forms `{eventType}.{attributeKey}={attributeValue}`.
+In the Cosmos SDK, events are implemented as an alias of the ABCI `event` type in the form `{eventType}.{attributeKey}={attributeValue}`.
 
-Events are objects that allow app developers to package important information about state transitions in an application. Instead of querying, events can be subscribed to using [websockets](https://docs.tendermint.com/master/tendermint-core/subscription.html#subscribing-to-events-via-websocket).
+Events are objects that allow application developers to package important information about state transitions in an application. Instead of querying, events can be subscribed to using [WebSockets](https://docs.tendermint.com/master/tendermint-core/subscription.html#subscribing-to-events-via-websocket).
 
 ```protobuf
 // Events allow application developers to attach additional information to
@@ -23,16 +23,17 @@ message Event {
 
 In the above, two elements stand out:
 
-* A `type` to categorize the event at a high-level. For example, the Cosmos SDK uses the `message` _type_ to filter events by `Msg`.
-* A list of `attributes` are key-value pairs that give more information about the categorized event. For example, for the `message` type, we can filter events by key-value pairs using `message.action={some_action}, message.module={some_module}` or `message.sender={a_sender}`.
+* A `type` to categorize the event at a high level. For example, the Cosmos SDK uses the `message` _type_ to filter events by `Msg`.
+* A list of `attributes`, which are key-value pairs giving more information about the categorized event. For example, for the `message` type, we can filter events by key-value pairs using `message.action={some_action}, message.module={some_module}` or `message.sender={a_sender}`.
 
-<HighlightBox type=”info”>
+<HighlightBox type="info">
 
 To parse the attribute values as strings, make sure to add `'` (single quotes) around each attribute value.
 
 </HighlightBox>
 
-Events, their type and attributes are defined on a per-module basis in the module's `/types/events.go` file, and are triggered from the module's Protobuf `Msg` service by using the `EventManager`. Additionally, each module documents its events under `spec/xx_events.md`.
+Events, their type, and attributes are defined on a per-module basis in the module's `/types/events.go` file.  Additionally, each module documents its events under `spec/xx_events.md`.
+
 Events are returned to the underlying consensus engine in response to the following ABCI messages:
 
 * `BeginBlock`
@@ -40,21 +41,24 @@ Events are returned to the underlying consensus engine in response to the follow
 * `CheckTx`
 * `DeliverTx`
 
-Events are managed by an abstraction called the `EventManager`.
+Events are managed by an abstraction called the `EventManager`. They are triggered from the module's Protobuf `Msg` service with `EventManager`.
 
-## EventManager
+## `EventManager`
 
-For each of the 4 ABCI calls, `CheckTx`, `DeliverTx`, `BeginBlock` and `EndBlock`, the `EventManager` keeps a list of events and delivers it in full as part of the ABCI response. After delivery in an ABCI response, the `EventManager` empties its list of events. In practice, the `EventManager` implements a simple wrapper around a slice of `Event` objects that can be emitted from and provides useful methods. The most often used method for Cosmos SDK module and application developers is `EmitEvent`.
+For each of the four ABCI calls, `CheckTx`, `DeliverTx`, `BeginBlock`, and `EndBlock`, the `EventManager` keeps a list of events and delivers it in full as part of the ABCI response. After delivery in an ABCI response, the `EventManager` empties its list of events.
 
-<HighlightBox type=”info”>
+In practice, the `EventManager` implements a simple wrapper around a slice of `Event` objects that can be emitted from and provides useful methods. One of the most-used methods by modules and application developers is `EmitEvent`.
 
-Module developers should handle event emission via the `EventManager#EmitEvent` in each message handler and in each `BeginBlock` or `EndBlock` handler, accessed via the `Context`, where event emission generally follows this pattern:
+<HighlightBox type="info">
+
+Module developers should handle event emission via `EventManager#EmitEvent` in each message handler and in each `BeginBlock` or `EndBlock` handler, accessed via the `Context`. Event emission generally follows this pattern:
 
 ```go
 func (em *EventManager) EmitEvent(event Event) {
     em.events = em.events.AppendEvent(event)
 }
 ```
+
 Each module's handler function should also set a new `EventManager` to the context to isolate emitted events per message:
 
 ```go
@@ -71,31 +75,33 @@ func NewHandler(keeper Keeper) sdk.Handler {
 
 </HighlightBox>
 
-## Subscribing to Events
+## Subscribing to events
 
-You can use Tendermint's [Websocket](https://docs.tendermint.com/master/tendermint-core/subscription.html#subscribing-to-events-via-websocket) to subscribe to events by calling the `subscribe` RPC method.
+You can use Tendermint's [WebSocket](https://docs.tendermint.com/master/tendermint-core/subscription.html#subscribing-to-events-via-websocket) to subscribe to events by calling the `subscribe` RPC method.
 
 The main `eventCategories` you can subscribe to are:
 
-* **NewBlock**: Contains Events triggered during `BeginBlock` and `EndBlock`.
-* **Tx**: Contains events triggered during `DeliverTx` (i.e. transaction processing).
-* **ValidatorSetUpdates**: Contains updates about the set of validators for the block.
+* **`NewBlock`:** contains Events triggered during `BeginBlock` and `EndBlock`.
+* **`Tx`:** contains events triggered during `DeliverTx` (transaction processing).
+* **`ValidatorSetUpdates`:** contains updates about the set of validators for the block.
 
 <HighlightBox type=”info”>
 
-→ You can find a full list of event categories [here](https://godoc.org/github.com/tendermint/tendermint/types#pkg-constants).
+You can find a full list of event categories in the [Tendermint Go documentation](https://godoc.org/github.com/tendermint/tendermint/types#pkg-constants).
 
 </HighlightBox>
 
 You can filter for event types and attribute values. For example, a transfer transaction triggers an event of type `Transfer` and has `Recipient` and `Sender` as attributes, as defined in the `events.go` file of the bank module.
 
-## Next Up
+## Next up
 
-You just learned about events, where they are expected, and how to emit or receive them. Have a look at the code samples below or head next to learn about the `Context` object in the [next section](./14-context).
+You just learned about events, where they are expected, and how to emit or receive them. Have a look at the code samples below or head to the [next section](./14-context) to learn about the `Context` object.
 
-<ExpansionPanel title="Show me some code for my checkers blockchain">
+<ExpansionPanel title="Show me some code for my checkers' blockchain">
 
-In your checkers blockchain, it would be good to document a game's lifecycle via events. For instance, when creating the game, you can emit a specific event such that:
+In your checkers' blockchain, it would be good to document a game's lifecycle via events.
+
+For instance, when creating the game, you can emit a specific event such that:
 
 ```go
 var ctx sdk.Context
@@ -112,7 +118,8 @@ ctx.EventManager().EmitEvent(
     ),
 )
 ```
-From this model, it is easy to add events to the other transaction types, where you keep in mind that the events are meant to inform and notify relevant parties.
+
+From this model, it is easy to add events to the other transaction types. Keep in mind that events are meant to inform and notify relevant parties.
 
 You should also emit an event for games that have timed out. After all, this is part of their lifecycle. You would do that in the end blocker:
 

--- a/b9lab-content/3-main-concepts/13-events.md
+++ b/b9lab-content/3-main-concepts/13-events.md
@@ -105,7 +105,7 @@ ctx.EventManager().EmitEvent(
 ```
 From this model, it is easy to add events to the other transaction types, where you keep in mind that the events are meant to inform and notify relevant parties.
 
-You ought to also emit an event for games that have timed out. After all, this is part of their lifecycle. You would do it in the end blocker:
+You should also emit an event for games that have timed out. After all, this is part of their lifecycle. You would do that in the end blocker:
 
 ```go
 ctx.EventManager().EmitEvent(

--- a/b9lab-content/3-main-concepts/13-events.md
+++ b/b9lab-content/3-main-concepts/13-events.md
@@ -1,11 +1,10 @@
 # Events
 
-# Events
 An event is an object that contains information about the execution of the application. Events are used by service providers (block explorers, wallets) to track execution of various messages and index transactions.
 
 In Cosmo SDK, events are implemented as an alias of ABCI `event` type in the forms `{eventType}.{attributeKey}={attributeValue}`.
 
-Events allow app devs to attach additional information. This means that transactions might be queried using the events:
+Events allow app developers to attach additional information. This means that transactions might be queried using the events:
 
 ```
 // Event allows application developers to attach additional information to
@@ -22,29 +21,32 @@ message Event {
 
 ## Structure
 
-* A `type` to categorize the Event at a high-level; for example, the SDK uses the "message" type to filter Events by Msgs.
-* A list of `attributes` are key-value pairs that give more information about the categorized Event. For example, for the "message" type, we can filter Events by key-value pairs using `message.action={some_action}, message.module={some_module}` or `message.sender={a_sender}`.
+* A `type` to categorize the Event at a high-level; for example, the Cosmos SDK uses the `message` _type_ to filter events by Msgs.
+* A list of `attributes` are key-value pairs that give more information about the categorized event. For example, for the "message" type, we can filter events by key-value pairs using `message.action={some_action}, message.module={some_module}` or `message.sender={a_sender}`.
 
 <HighlightBox type=”info”>
-To parse the attribute values as strings, make sure to add ' (single quotes) around each attribute value
+
+To parse the attribute values as strings, make sure to add `'` (single quotes) around each attribute value.
+
 </HighlightBox>
 
-Events, the type and attributes are defined on a per-module basis in the module's `/types/events.go` file, and are triggered from the module's Protobuf Msg service by using the EventManager. Additionally, each module documents its Events under `spec/xx_events.md`.
+Events, their type and attributes are defined on a per-module basis in the module's `/types/events.go` file, and are triggered from the module's Protobuf Msg service by using the `EventManager`. Additionally, each module documents its events under `spec/xx_events.md`.
 Events are returned to the underlying consensus engine in response to the following ABCI messages:
 
-* BeginBlock
-* EndBlock
-* CheckTx
-* DeliverTx
+* `BeginBlock`
+* `EndBlock`
+* `CheckTx`
+* `DeliverTx`
 
 Events are managed by an abstraction called the `EventManager`.
 
 ## EventManager
 
-Eventmanager tracks a list of Events for the entire execution flow of a transaction or BeginBlock/EndBlock. EventManager implements a simple wrapper around a slice of Event objects that can be emitted from and provides useful methods. The most used method for Cosmos SDK module and application developers is `EmitEvent`.
+`EventManager` tracks a list of events for the entire execution flow of a transaction or `BeginBlock`/`EndBlock`. `EventManager` implements a simple wrapper around a slice of `Event` objects that can be emitted from and provides useful methods. The most used method for Cosmos SDK module and application developers is `EmitEvent`.
 
 <HighlightBox type=”info”>
-Module developers should handle Event emission via the EventManager#EmitEvent in each message Handler and in each BeginBlock/EndBlock handler, accessed via the Context, where Event emission generally follows this pattern: 
+
+Module developers should handle event emission via the `EventManager#EmitEvent` in each message handler and in each `BeginBlock`/`EndBlock` handler, accessed via the `Context`, where event emission generally follows this pattern:
 
 ```
 func (em *EventManager) EmitEvent(event Event) {
@@ -52,7 +54,7 @@ func (em *EventManager) EmitEvent(event Event) {
 }
 ```
 
-Each module's handler function should also set a new EventManager to the context to isolate emitted Events per message:
+Each module's handler function should also set a new `EventManager` to the context to isolate emitted events per message:
 
 ```
 func NewHandler(keeper Keeper) sdk.Handler {
@@ -61,35 +63,59 @@ func NewHandler(keeper Keeper) sdk.Handler {
         switch msg := msg.(type) {
     // event types
 ```
-</HighlightBox>
 
+</HighlightBox>
 
 ## Subscribing to Events
 
-You can use Tendermint's Websocket (opens new window) to subscribe to Events by calling the subscribe RPC method.
+You can use Tendermint's Websocket (opens new window) to subscribe to events by calling the subscribe RPC method.
 
-The main eventCategories you can subscribe to are:
+The main `eventCategories` you can subscribe to are:
 
-* **NewBlock**: Contains Events triggered during BeginBlock and EndBlock.
-* **Tx**: Contains Events triggered during DeliverTx (i.e. transaction processing).
+* **NewBlock**: Contains Events triggered during `BeginBlock` and `EndBlock`.
+* **Tx**: Contains events triggered during `DeliverTx` (i.e. transaction processing).
 * **ValidatorSetUpdates**: Contains validator set updates for the block.
 
 <HighlightBox type=”info”>
-→ full list of event categories at: https://godoc.org/github.com/tendermint/tendermint/types#pkg-constants
+
+→ full list of event categories [here](https://godoc.org/github.com/tendermint/tendermint/types#pkg-constants)
+
 </HighlightBox>
 
-You can filter for event types and attribute values.For example, a transfer transaction triggers an Event of type Transfer and has Recipient and Sender as attributes (as defined in the events.go file of the bank module
+You can filter for event types and attribute values. For example, a transfer transaction triggers an event of type `Transfer` and has `Recipient` and `Sender` as attributes (as defined in the `events.go` file of the bank module.
 
-## Long-running exercise
+<ExpansionPanel title="Show me some code for my checkers blockchain">
 
-We want to surface some information that is usable for server systems and GUIs:
+In your checkers blockchain, it would be good to document a game's lifecycle via events. For instance, when creating the game, you can emit a specific event such that:
 
-* Per transaction:
-    * The game was created. Both players need to be notified.
-    * The player has played. The other player needs to be notified.
-    * The game was rejected. The other player needs to be notified.
-    * Perhaps the game was won. Both players need to be notified.
-* Per block:
-    * These games timed out. The game ids and the involved players need to be notified.
+```go
+var ctx sdk.Context
+ctx.EventManager().EmitEvent(
+    sdk.NewEvent(sdk.EventTypeMessage,
+        sdk.NewAttribute(sdk.AttributeKeyModule, "checkers"),
+        sdk.NewAttribute(sdk.AttributeKeyAction, "NewGameCreated"),
+        sdk.NewAttribute("Creator", msg.Creator),
+        sdk.NewAttribute("Index", newIndex),
+        sdk.NewAttribute("Red", msg.Red),
+        sdk.NewAttribute("Black", msg.Black),
+        sdk.NewAttribute("Wager", strconv.FormatUint(msg.Wager, 10)),
+        sdk.NewAttribute("Token", msg.Token),
+    ),
+)
+```
+From this model, it is easy to add events to the other transaction types, where you keep in mind that the events are meant to inform and notify relevant parties.
 
-TODO implement them.
+You ought to also emit an event for games that have timed out. After all, this is part of their lifecycle. You would do it in the end blocker:
+
+```go
+ctx.EventManager().EmitEvent(
+    sdk.NewEvent(sdk.EventTypeMessage,
+        sdk.NewAttribute(sdk.AttributeKeyModule, "checkers"),
+        sdk.NewAttribute(sdk.AttributeKeyAction, "GameForfeited"),
+        sdk.NewAttribute("IdValue", storedGameId),
+        sdk.NewAttribute("Winner", rules.NO_PLAYER.Color), // Or the rightful winner.
+    ),
+)
+```
+
+</ExpansionPanel>

--- a/b9lab-content/3-main-concepts/13-events.md
+++ b/b9lab-content/3-main-concepts/13-events.md
@@ -4,7 +4,7 @@ An event is an object that contains information about the execution of the appli
 
 In the Cosmos SDK, events are implemented as an alias of the ABCI `event` type in the forms `{eventType}.{attributeKey}={attributeValue}`.
 
-Events allow app developers to attach additional information. This means that transactions might be queried using the events:
+Events are objects that allow app developers to package important information about state transitions in an application. Instead of querying, events can be subscribed to using [websockets](https://docs.tendermint.com/master/tendermint-core/subscription.html#subscribing-to-events-via-websocket).
 
 ```
 // Events allows application developers to attach additional information to
@@ -20,6 +20,8 @@ message Event {
 ```
 
 ## Structure
+
+In the above, two elements stand out:
 
 * A `type` to categorize the Event at a high-level; for example, the Cosmos SDK uses the `message` _type_ to filter events by Msgs.
 * A list of `attributes` are key-value pairs that give more information about the categorized event. For example, for the "message" type, we can filter events by key-value pairs using `message.action={some_action}, message.module={some_module}` or `message.sender={a_sender}`.


### PR DESCRIPTION
Docs content update for Module 3, Section _Queries, Events_ - part of the [b9lab-content](https://github.com/cosmos/sdk-tutorials/tree/master/b9lab-content).

This PR adds code samples to the content. The code shown here is taken from the [code example repo](https://github.com/cosmos/b9-checkers-academy-draft/) and has been hardly adjusted. The repo has been reviewed so no need to review it here. What we are looking for is to make sure that the introductory texts are not misleading or even downright wrong.

### Content state

**✔️ Completed**

### Technical review
- [x] requested
- [x] completed

### Language review
- [x] requested
- [x] completed
