### PR TITLE
WIP: docs: Module 5 Starport - code sample integration 1 of 3 (B9lab updates 4-3)

### DIFF
--- a/b9lab-content/5-my-own-chain/03-starport-03-stored-game.md
+++ b/b9lab-content/5-my-own-chain/03-starport-03-stored-game.md
@@ -1,16 +1,36 @@
 ---
-title: The Stored Game Object
+title: Make a Checkers Blockchain
 order: 4
 description: You create the object that stores a game.
 ---
 
+# Make a Checkers Blockchain
+
+With Starport, you learned how to jump-start a brand new blockchain. Let's dive deeper and see how you would go about creating one that lets people play the game of checkers in a decentralized fashion.
+
+_The_ game of checkers? Ok, there are many versions of the rules. Let's choose [those](https://www.ducksters.com/games/checkers_rules.php). Also, the object of the deep dive is to learn about Starport and the Cosmos SDK, not to get lost in the proper implementation of the board state or of the rules of checkers. So let's use [this ready-made implementation](https://github.com/batkinson/checkers-go/blob/a09daeb/checkers/checkers.go), with the additional rule that the board is 8x8 and played on black cells. It so happens that this code will not need adjustments. Also, you are not going to be overly concerned with a marketable GUI since, again, that would be a separate project in itself. Of course, you still need to concern yourself with creating the groundwork for a GUI to be possible in the first place.
+
+Here goes. If you did not already do it in the previous section, create your brand new blockchain with a `checkers` module:
+
+```sh
+$ starport scaffold chain github.com/alice/checkers
+```
+When it is all done, copy the [rules file](https://github.com/batkinson/checkers-go/blob/a09daeb/checkers/checkers.go) into a `rules` folder inside your module, and change its package from `checkers` to `rules`. Let's do it by command-line, because why not:
+
+```sh
+$ cd checkers
+$ mkdir x/checkers/rules
+$ curl https://raw.githubusercontent.com/batkinson/checkers-go/a09daeb1548dd4cc0145d87c8da3ed2ea33a62e3/checkers/checkers.go | sed 's/package checkers/package rules/' > x/checkers/rules/checkers.go
+```
+With this done, it is time to move on to the first object to create.
+
 # The Stored Game Object
 
-With the base project and `checkers` module created and checkers rules imported, you can now focus on what is the minimum game information you need to keep in storage.
+Let's start with what is the minimum game information you need to keep in storage. No need to burden yourself with all bells and whistles at the start.
 
 * The red player: a string, the serialized address.
 * The black player: a string, the serialized address.
-* The game proper: a string, the game as it is serialized by the rules file.
+* The game proper: a string, the game as it is serialized by the _rules_ file.
 * Which player is to play next: a string.
 
 ## How To Store It
@@ -54,7 +74,7 @@ Which will be used to prefix the keys at which the objects are stored.
 
 As you know, Starport creates the Protobuf objects first in the `proto` directory before compiling them. Therefore you have the `NextGame` object:
 
-```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/next_game.proto#L8-L11]
+```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/next_game.proto#L8-L11]
 message NextGame {
     string creator = 1;
     uint64 idValue = 2;
@@ -62,7 +82,7 @@ message NextGame {
 ```
 And the `StoredGame` object:
 
-```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/stored_game.proto#L8-L15]
+```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/stored_game.proto#L8-L15]
 message StoredGame {
     string creator = 1;
     string index = 2;
@@ -94,7 +114,7 @@ type StoredGame struct {
 ```
 These are not the only Protobuf objects created. The genesis state is also defined in Protobuf, therefore you have:
 
-```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/genesis.proto#L11-L16]
+```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/genesis.proto#L11-L16]
 import "checkers/stored_game.proto";
 import "checkers/next_game.proto";
 
@@ -113,7 +133,7 @@ type GenesisState struct {
 ```
 As part of the boilerplate objects created by Starport there are objects to query and receive these new meaty objects. In the case of `NextGame`, it looks a bit out of place, but keep in mind that Starport creates them according to a versatile model, which does not prevent you from making changes down the road:
 
-```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L51-L55]
+```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L51-L55]
 message QueryGetNextGameRequest {}
 
 message QueryGetNextGameResponse {
@@ -122,7 +142,7 @@ message QueryGetNextGameResponse {
 ```
 In the case of the query objects for `StoredGame`, they look convenient:
 
-```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L35-L50]
+```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L35-L50]
 message QueryGetStoredGameRequest {
     string index = 1;
 }
@@ -152,7 +172,7 @@ Notice how Starport has filed the different Protobuf messages into different fil
 
 As a note on the files Starport updates down the road, observe how those files have comments like:
 
-```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L14]
+```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L14]
 // this line is used by starport scaffolding # 2
 ```
 Starport adds code right below them so keep these comments in place and you shall be fine. You can add your own code above or below, though.
@@ -177,7 +197,7 @@ Here, you can choose to start with no games, or, for some obscure reason, insert
 
 Beyond these created objects, Starport also created services that declare and define how to access the newly created storage objects. More precisely, when Starport created your module, it introduced empty service interfaces that it can fill in as you add objects and messages. In particular, it added to `service Query` how to query for your objects:
 
-```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L16-L30]
+```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L16-L30]
 service Query {
     rpc StoredGame(QueryGetStoredGameRequest) returns (QueryGetStoredGameResponse) {
         option (google.api.http).get = "/xavierlepretre/checkers/checkers/storedGame/{index}";

--- a/b9lab-content/5-my-own-chain/03-starport-03-stored-game.md
+++ b/b9lab-content/5-my-own-chain/03-starport-03-stored-game.md
@@ -52,7 +52,7 @@ Which will be used to prefix the keys at which the objects are stored.
 
 ## Protobuf Objects
 
-As you know, Starport creates the Protobuf objects first before compiling them. Therefore you have the `NextGame` object:
+As you know, Starport creates the Protobuf objects first in the `proto` directory before compiling them. Therefore you have the `NextGame` object:
 
 ```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/next_game.proto#L8-L11]
 message NextGame {

--- a/b9lab-content/5-my-own-chain/03-starport-03-stored-game.md
+++ b/b9lab-content/5-my-own-chain/03-starport-03-stored-game.md
@@ -1,0 +1,202 @@
+---
+title: The Stored Game Object
+order: 4
+description: You create the object that stores a game.
+---
+
+# The Stored Game Object
+
+With the base project and `checkers` module created and checkers rules imported, you can now focus on what is the minimum game information you need to keep in storage.
+
+* The red player: a string, the serialized address.
+* The black player: a string, the serialized address.
+* The game proper: a string, the game as it is serialized by the rules file.
+* Which player is to play next: a string.
+
+## How To Store It
+
+After having decided **what** to store, you have to decide **how** to store a game. You want your blockchain application to accommodate multiple simultaneous games on a equal footing. This calls for each game to be identified by an id, and to be retrievable by the same id.
+
+How do you create such an id? You cannot let players choose it as that will lead to transactions failing for the silly reason that the proposed id is already taken. It is better to have a counter incrementing on each new game. This is possible because the code execution happens in a single thread. Moreover, you cannot rely on a large random number, like a UUID, because transactions have to be verifiable in the future.
+
+You also need to keep this counter in storage in between transactions. Instead of a single counter, you can instead keep a unique object at a singular location. This way you can easily add to it when the need arises. Let's call `idValue` the counter.
+
+Starport to the rescue:
+
+* For the counter, or rather the object that contains it, let's call it `NextGame` and instruct Starport with `scaffold single`:
+    ```sh
+    $ starport scaffold single nextGame idValue:uint --module checkers --no-message
+    ```
+    You need to add `--no-message` so as to not expose the counter to the outside world via a simple CRUD interface. After all, you want to keep control of how this counter increments.
+* For games saved by id, it calls this a map, and, if you choose the `StoredGame` name, you instruct Starport with `scaffold map`:
+    ```sh
+    $ starport scaffold map storedGame game turn red black --module checkers --no-message
+    ```
+
+This has created a certain number of files as can be seen [here](https://github.com/cosmos/b9-checkers-academy-draft/commit/821f4592d78e5d689dcc349613c8efb11386f785) and [there](https://github.com/cosmos/b9-checkers-academy-draft/commit/463968fa94a7b6117428bb342c721176086a8d22).
+
+For starters, it has added new keys:
+
+```go
+const (
+    NextGameKey = "NextGame-value-"
+)
+
+const (
+    StoredGameKey = "StoredGame-value-"
+)
+```
+Which will be used to prefix the keys at which the objects are stored.
+
+## Protobuf Objects
+
+As you know, Starport creates the Protobuf objects first before compiling them. Therefore you have the `NextGame` object:
+
+```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/463968fa94a7b6117428bb342c721176086a8d22/proto/checkers/next_game.proto#L8-L11]
+message NextGame {
+    string creator = 1;
+    uint64 idValue = 2;
+}
+```
+And the `StoredGame` object:
+
+```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/821f4592d78e5d689dcc349613c8efb11386f785/proto/checkers/stored_game.proto#L8-L15]
+message StoredGame {
+    string creator = 1;
+    string index = 2;
+    string game = 3;
+    string turn = 4;
+    string red = 5;
+    string black = 6;
+}
+```
+Both of them predictably compiled into:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/463968fa94a7b6117428bb342c721176086a8d22/x/checkers/types/next_game.pb.go#L26-L29]
+type NextGame struct {
+    Creator string `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
+    IdValue uint64 `protobuf:"varint,2,opt,name=idValue,proto3" json:"idValue,omitempty"`
+}
+```
+And:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/821f4592d78e5d689dcc349613c8efb11386f785/x/checkers/types/stored_game.pb.go#L26-L33]
+type StoredGame struct {
+    Creator string `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
+    Index   string `protobuf:"bytes,2,opt,name=index,proto3" json:"index,omitempty"`
+    Game    string `protobuf:"bytes,3,opt,name=game,proto3" json:"game,omitempty"`
+    Turn    string `protobuf:"bytes,4,opt,name=turn,proto3" json:"turn,omitempty"`
+    Red     string `protobuf:"bytes,5,opt,name=red,proto3" json:"red,omitempty"`
+    Black   string `protobuf:"bytes,6,opt,name=black,proto3" json:"black,omitempty"`
+}
+```
+These are not the only Protobuf objects created. The genesis state is also defined in Protobuf, therefore we have:
+
+```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/821f4592d78e5d689dcc349613c8efb11386f785/proto/checkers/genesis.proto#L11-L16]
+import "checkers/stored_game.proto";
+import "checkers/next_game.proto";
+
+message GenesisState {
+    repeated StoredGame storedGameList = 2;
+    NextGame nextGame = 1;
+}
+```
+Which is compiled into:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/821f4592d78e5d689dcc349613c8efb11386f785/x/checkers/types/genesis.pb.go#L26-L30]
+type GenesisState struct {
+    StoredGameList []*StoredGame `protobuf:"bytes,2,rep,name=storedGameList,proto3" json:"storedGameList,omitempty"`
+    NextGame       *NextGame     `protobuf:"bytes,1,opt,name=nextGame,proto3" json:"nextGame,omitempty"`
+}
+```
+As part of the boilerplate objects created by Starport there are objects to query and receive these new meaty objects. In the case of `NextGame`, it looks a bit out of place, but keep in mind that Starport creates them according to a versatile model, which does not prevent you from making changes down the road:
+
+```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/821f4592d78e5d689dcc349613c8efb11386f785/proto/checkers/query.proto#L51-L55]
+message QueryGetNextGameRequest {}
+
+message QueryGetNextGameResponse {
+     NextGame NextGame = 1;
+}
+```
+In the case of the query objects for `StoredGame`, they look convenient:
+
+```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/821f4592d78e5d689dcc349613c8efb11386f785/proto/checkers/query.proto#L35-L50]
+message QueryGetStoredGameRequest {
+    string index = 1;
+}
+
+message QueryGetStoredGameResponse {
+    StoredGame StoredGame = 1;
+}
+
+message QueryAllStoredGameRequest {
+    cosmos.base.query.v1beta1.PageRequest pagination = 1;
+}
+
+message QueryAllStoredGameResponse {
+    repeated StoredGame StoredGame = 1;
+    cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+```
+
+## Starport's Modus Operandi
+
+Notice how Starport has filed the different Protobuf messages into different files depending on their eventual use:
+
+* `query.proto` for the objects related to asking queries, i.e. reading the state. Plus a service, see below. This file will be modified by Starport as you add queries.
+* `tx.proto` for the objects that relate to updating the state. For now it is empty, and with good reason since you have only defined storage elements for now. This file will be modified too as you add transaction-related elements.
+* `genesis.proto` for the genesis as it evolves with your new storage elements. Starport will modify this file too.
+* `next_game.proto` and `stored_game.proto`, separate files that were created once and that Starport will not touch again. You are free to modify them and be careful with the numbering.
+
+As a note on the files Starport updates down the road, observe how those files have comments like:
+
+```
+// this line is used by starport scaffolding # 2
+```
+Starport adds code right below them so keep these comments in place and you shall be fine. You can add your own code above or below, though.
+
+On the other hand, you should not modify the Protobuf-compiled files, named `*.pb.go` and `*.pb.gw.go`, as they are recreated on every re-run of Starport. There are other files, also created by Starport, that you can update.
+
+## Files To Adjust
+
+Starport created files that you can and should update as you see fit. For instance, the default genesis values:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/821f4592d78e5d689dcc349613c8efb11386f785/x/checkers/types/genesis.go#L16-L17]
+func DefaultGenesis() *GenesisState {
+    return &GenesisState{
+        StoredGameList: []*StoredGame{},
+        NextGame:       &NextGame{"", uint64(0)},
+    }
+}
+```
+Here, you can choose to start with no games, or, for some obscure reason, insert a number of them. More to the point, you ought also to choose the first id of the first game. Here, it will be `0`.
+
+## Protobuf Service Interfaces
+
+Beyond these created objects, Starport also created services that declare and define how to access the newly created storage objects. More precisely, when Starport created your module, it introduced empty service interfaces that it can fill in as you add objects and messages. In particular, it added to `service Query` how to query for your objects:
+
+```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/821f4592d78e5d689dcc349613c8efb11386f785/proto/checkers/query.proto#L16-L30]
+service Query {
+    rpc StoredGame(QueryGetStoredGameRequest) returns (QueryGetStoredGameResponse) {
+        option (google.api.http).get = "/xavierlepretre/checkers/checkers/storedGame/{index}";
+    }
+
+    rpc StoredGameAll(QueryAllStoredGameRequest) returns (QueryAllStoredGameResponse) {
+        option (google.api.http).get = "/xavierlepretre/checkers/checkers/storedGame";
+    }
+
+    rpc NextGame(QueryGetNextGameRequest) returns (QueryGetNextGameResponse) {
+        option (google.api.http).get = "/xavierlepretre/checkers/checkers/nextGame";
+    }
+}
+```
+As for the compilation of such a service, Starport takes a somewhat circuitous route, whose purpose is to separate concerns into different files, some you should not edit, and others you can:
+
+* Serialization of the query parameters, and their conforming to the right Protobuf `Message` interface.
+* The primary implementation of the gRPC service.
+* The implementation of all the storage setters and getters as extra functions in the keeper.
+* The implementation, in the keeper, of the storage getters as they come from the gRPC server.
+
+## Conclusion
+
+At this point, Starport got you covered, and you did not have to do much. Sure you had to confirm the correct genesis value of `NextGame.IdValue`.

--- a/b9lab-content/5-my-own-chain/03-starport-03-stored-game.md
+++ b/b9lab-content/5-my-own-chain/03-starport-03-stored-game.md
@@ -1,63 +1,73 @@
 ---
-title: Make a Checkers Blockchain
+title: Make a Checkers' Blockchain
 order: 4
-description: You create the object that stores a game.
+description: You create the object that stores a game
+tag: deep-dive
 ---
 
-# Make a Checkers Blockchain
+# Make a Checkers' Blockchain
 
-With Starport, you learned how to jump-start a brand new blockchain. Let's dive deeper and see how you would go about creating one that lets people play the game of checkers in a decentralized fashion.
+In the [Starport introduction section](./03-starport.md), you learned how to jump-start a brand new blockchain. Let's dive deeper and explore how you can create a blockchain that lets people play the game of checkers in a decentralized fashion.
 
-_The_ game of checkers? Ok, there are many versions of the rules. Let's choose [those](https://www.ducksters.com/games/checkers_rules.php). Also, the object of the deep dive is to learn about Starport and the Cosmos SDK, not to get lost in the proper implementation of the board state or of the rules of checkers. So let's use [this ready-made implementation](https://github.com/batkinson/checkers-go/blob/a09daeb/checkers/checkers.go), with the additional rule that the board is 8x8 and played on black cells. It so happens that this code will not need adjustments. Also, you are not going to be overly concerned with a marketable GUI since, again, that would be a separate project in itself. Of course, you still need to concern yourself with creating the groundwork for a GUI to be possible in the first place.
+_The_ game of checkers? Ok, there are many versions of the rules. Let's choose [a very simple set of basic rules](https://www.ducksters.com/games/checkers_rules.php). The objective of this deep dive is to get acquainted with Starport and the Cosmos SDK, not to get lost in the rules of checkers or the proper implementation of the board state.
 
-Here goes. If you did not already do it in the previous section, create your brand new blockchain with a `checkers` module:
+Let's use [a ready-made implementation](https://github.com/batkinson/checkers-go/blob/a09daeb/checkers/checkers.go), with the additional rule that the board is 8x8 and played on black cells. This code will not need adjustments.
+
+You are not going to be overly concerned with a marketable GUI. That would be a separate project in itself. Of course, you still need to concern yourself with creating the groundwork for a GUI to be possible in the first place.
+
+If you did not already do it in the [previous section](./03-starport.md), create your brand new blockchain with a `checkers` module:
 
 ```sh
 $ starport scaffold chain github.com/alice/checkers
 ```
-When it is all done, copy the [rules file](https://github.com/batkinson/checkers-go/blob/a09daeb/checkers/checkers.go) into a `rules` folder inside your module, and change its package from `checkers` to `rules`. Let's do it by command-line, because why not:
+
+When it is all done, copy the [rules file](https://github.com/batkinson/checkers-go/blob/a09daeb/checkers/checkers.go) into a `rules` folder inside your module. Change its package from `checkers` to `rules`. You can do this by command-line:
 
 ```sh
 $ cd checkers
 $ mkdir x/checkers/rules
 $ curl https://raw.githubusercontent.com/batkinson/checkers-go/a09daeb1548dd4cc0145d87c8da3ed2ea33a62e3/checkers/checkers.go | sed 's/package checkers/package rules/' > x/checkers/rules/checkers.go
 ```
-With this done, it is time to move on to the first object to create.
 
-# The Stored Game Object
+With this done, it is time to move on to creating the first object.
 
-Let's start with what is the minimum game information you need to keep in storage. No need to burden yourself with all bells and whistles at the start.
+## The stored game object
+
+No need to burden yourself with all bells and whistles from the start. Let's start with what is the minimum game information you need to keep in the storage:
 
 * The red player: a string, the serialized address.
 * The black player: a string, the serialized address.
 * The game proper: a string, the game as it is serialized by the _rules_ file.
 * Which player is to play next: a string.
 
-## How To Store It
+### How to store
 
-After having decided **what** to store, you have to decide **how** to store a game. You want your blockchain application to accommodate multiple simultaneous games on an equal footing. This calls for each game to be identified by an id, and to be retrievable by the same id.
+After having decided **what** to store, you have to decide **how** to store a game. This is important if you want your blockchain application to accommodate multiple simultaneous games on an equal footing. This calls for each game to be identified by an ID, and to be retrievable by the same ID.
 
-How do you create such an id? You cannot let players choose it as that could lead to transactions failing for the silly reason that the proposed id is already taken. It is better to have a counter incrementing on each new game. This is possible because the code execution happens in a single thread. Moreover, you cannot rely on a large random number, like a UUID, because transactions have to be verifiable in the future.
+How do you create such an ID? You cannot let players choose it as that could lead to transactions failing for the silly reason that the proposed ID is already taken. It is better to have a counter incrementing on each new game. This is possible because the code execution happens in a single thread. Moreover, you cannot rely on a large random number, like a universally unique identifier (UUID), because transactions have to be verifiable in the future.
 
-You also need to keep this counter in storage in between transactions. Instead of a single counter, you can instead keep a unique object at a singular location. This way you can easily add to it when the need arises. Let's call `idValue` the counter.
+You need to keep such a counter in storage in between transactions. Instead of a single counter, you can keep a unique object at a singular location instead. Then you can easily add to the counter when the need arises. Let's call `idValue` the counter.
 
-Starport to the rescue:
+<!-- Are we calling idValue the counter, or are we determining idValue as the counter, or is idValue always a good counter in general? Please check and be more specific in the last sentence before the comment. -->
 
-* For the counter, or rather the object that contains it, let's call it `NextGame` and instruct Starport with `scaffold single`:
+You can rely on Starport for assistance:
+
+* For the counter, or rather the object that contains it, call it `NextGame` and instruct Starport with `scaffold single`:
     ```sh
     $ starport scaffold single nextGame idValue:uint --module checkers --no-message
     ```
-    You need to add `--no-message` so as to not expose the counter to the outside world via a simple CRUD interface. After all, you want to keep control of how this counter increments.
-* For games saved by id, it calls this a map, and, if you choose the `StoredGame` name, you instruct Starport with `scaffold map`:
+    You need to add `--no-message` to not expose the counter to the outside world via a simple CRUD interface. After all, you want to keep control of how this counter increments.
+* For games saved by ID, it calls this a map, and, if you choose the `StoredGame` name, you instruct Starport with `scaffold map`:
+
     ```sh
     $ starport scaffold map storedGame game turn red black --module checkers --no-message
     ```
 
-Why the `--no-message`? Well, you don't want these objects to be created or overwritten with a simple message. Instead they are to be created and updated by the application when it receives properly crafted messages like _create game_ or _play a move_.
+Why the `--no-message`? You do not want the objects to be created or overwritten with a simple message. Instead, they are to be created and updated by the application when it receives properly crafted messages, like _create game_ or _play a move_.
 
-This has created a certain number of files as can be seen [here](https://github.com/cosmos/b9-checkers-academy-draft/commit/821f4592d78e5d689dcc349613c8efb11386f785) and [there](https://github.com/cosmos/b9-checkers-academy-draft/commit/463968fa94a7b6117428bb342c721176086a8d22).
+This has created a certain number of files as you can see [here](https://github.com/cosmos/b9-checkers-academy-draft/commit/821f4592d78e5d689dcc349613c8efb11386f785) and [there](https://github.com/cosmos/b9-checkers-academy-draft/commit/463968fa94a7b6117428bb342c721176086a8d22).
 
-For starters, it has added new keys:
+For starters, it added new keys:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/x/checkers/types/keys.go#L28-L34]
 const (
@@ -68,11 +78,14 @@ const (
     StoredGameKey = "StoredGame-value-"
 )
 ```
+
 Which will be used to prefix the keys at which the objects are stored.
 
-## Protobuf Objects
+<!-- What will be? Please be more explicit. -->
 
-As you know, Starport creates the Protobuf objects first in the `proto` directory before compiling them. Therefore you have the `NextGame` object:
+### Protobuf objects
+
+As you know, Starport creates the Protobuf objects in the `proto` directory first, before compiling them. Therefore, you have a `NextGame` object:
 
 ```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/next_game.proto#L8-L11]
 message NextGame {
@@ -80,7 +93,8 @@ message NextGame {
     uint64 idValue = 2;
 }
 ```
-And the `StoredGame` object:
+
+And a `StoredGame` object:
 
 ```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/stored_game.proto#L8-L15]
 message StoredGame {
@@ -92,7 +106,8 @@ message StoredGame {
     string black = 6;
 }
 ```
-Both of them predictably compiled into:
+
+Both objects predictably compiled:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/x/checkers/types/next_game.pb.go#L26-L29]
 type NextGame struct {
@@ -112,7 +127,8 @@ type StoredGame struct {
     Black   string `protobuf:"bytes,6,opt,name=black,proto3" json:"black,omitempty"`
 }
 ```
-These are not the only Protobuf objects created. The genesis state is also defined in Protobuf, therefore you have:
+
+These are not the only created Protobuf objects. The genesis state is also defined in Protobuf, therefore, you have:
 
 ```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/genesis.proto#L11-L16]
 import "checkers/stored_game.proto";
@@ -123,6 +139,7 @@ message GenesisState {
     NextGame nextGame = 1;
 }
 ```
+
 Which is compiled into:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/x/checkers/types/genesis.pb.go#L26-L30]
@@ -131,7 +148,8 @@ type GenesisState struct {
     NextGame       *NextGame     `protobuf:"bytes,1,opt,name=nextGame,proto3" json:"nextGame,omitempty"`
 }
 ```
-As part of the boilerplate objects created by Starport there are objects to query and receive these new meaty objects. In the case of `NextGame`, it looks a bit out of place, but keep in mind that Starport creates them according to a versatile model, which does not prevent you from making changes down the road:
+
+As part of the boilerplate objects created by Starport, there are objects to query and receive these new objects. `NextGame` looks a bit out of place, but keep in mind that Starport creates the objects according to a versatile model. This does not prevent you from making changes down the road:
 
 ```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L51-L55]
 message QueryGetNextGameRequest {}
@@ -140,7 +158,10 @@ message QueryGetNextGameResponse {
      NextGame NextGame = 1;
 }
 ```
-In the case of the query objects for `StoredGame`, they look convenient:
+
+The query objects for `StoredGame` look convenient:
+
+<!-- What is meant by convenient? Please be more explicit. -->
 
 ```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L35-L50]
 message QueryGetStoredGameRequest {
@@ -161,27 +182,28 @@ message QueryAllStoredGameResponse {
 }
 ```
 
-## Starport's Modus Operandi
+### Starport's modus operandi
 
-Notice how Starport has filed the different Protobuf messages into different files depending on their eventual use:
+Notice how Starport files the different Protobuf messages into different files depending on their eventual use:
 
-* `query.proto` for the objects related to asking queries, i.e. reading the state. Plus a service, see below. This file will be modified by Starport as you add queries.
-* `tx.proto` for the objects that relate to updating the state. For now it is empty, and with good reason since you have only defined storage elements with `--no-message` for now. This file will be modified too as you add transaction-related elements.
-* `genesis.proto` for the genesis as it evolves with your new storage elements. Starport will modify this file too.
-* `next_game.proto` and `stored_game.proto`, separate files that were created once and that Starport will not touch again. You are free to modify them and be careful with the numbering.
+* `query.proto`: for the objects related to asking queries (reading the state). Starport modifies this file as you add queries.
+* `tx.proto`: for the objects that relate to updating the state. It is empty for now, as you have only defined storage elements with `--no-message`. This file will be modified as you add transaction-related elements.
+* `genesis.proto`: for the genesis. As it evolves with your new storage elements, Starport modifies this file.
+* `next_game.proto` and `stored_game.proto`: separate files created once that remain untouched by Starport after their creation. You are free to modify them, but be careful with the numbering.
 
-As a note on the files Starport updates down the road, observe how those files have comments like:
+As a note on files Starport updates, observe how such files have comments similar to:
 
 ```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L14]
 // this line is used by starport scaffolding # 2
 ```
-Starport adds code right below them so keep these comments in place and you shall be fine. You can add your own code above or below, though.
 
-On the other hand, you should not modify the Protobuf-compiled files, named `*.pb.go` and `*.pb.gw.go`, as they are recreated on every re-run of Starport. There are other files, also created by Starport, that you can update.
+Starport adds code right below the comments, so keep these comments where they are and you shall be fine. You can add your code above or below though.
 
-## Files To Adjust
+Some files created by Starport can be updated, but you should not modify the Protobuf-compiled files, named `*.pb.go` and `*.pb.gw.go`, as they are recreated on every re-run of Starport. Let's take a closer look at files to adjust.
 
-Starport created files that you can and should update as you see fit. For instance, the default genesis values:
+### Files to adjust
+
+Starport created files that you can and should update as you see fit. For instance when it comes to the default genesis values:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/x/checkers/types/genesis.go#L16-L17]
 func DefaultGenesis() *GenesisState {
@@ -191,11 +213,12 @@ func DefaultGenesis() *GenesisState {
     }
 }
 ```
-Here, you can choose to start with no games, or, for some obscure reason, insert a number of them. More to the point, you ought also to choose the first id of the first game. Here, it will be `0`.
 
-## Protobuf Service Interfaces
+Here, you can choose to start with no games or, for some obscure reason, insert a number of games to start with. Choose the first ID of the first game. For the start, go with `0`.
 
-Beyond these created objects, Starport also created services that declare and define how to access the newly created storage objects. More precisely, when Starport created your module, it introduced empty service interfaces that it can fill in as you add objects and messages. In particular, it added to `service Query` how to query for your objects:
+### Protobuf service interfaces
+
+Beyond these created objects, Starport also creates services that declare and define how to access the newly created storage objects. More precisely, when Starport creates your module, it introduces empty service interfaces that can be filled in as you add objects and messages. In particular, it added to `service Query` how to query for your objects:
 
 ```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/d2a72b4ca9064a7e3e5014ba204ed01a4fe81468/proto/checkers/query.proto#L16-L30]
 service Query {
@@ -212,13 +235,14 @@ service Query {
     }
 }
 ```
-As for the compilation of such a service, Starport takes a somewhat circuitous route, whose purpose is to separate concerns into different files, some you should not edit, and others you can:
 
-* Serialization of the query parameters, and their conforming to the right Protobuf `Message` interface.
+In the compilation of such a service, Starport takes a somewhat circuitous route to separate concerns into different files, some you should not edit, and others you can:
+
+* Serialize the query parameters and make them conform to the right Protobuf `Message` interface.
 * The primary implementation of the gRPC service.
 * The implementation of all the storage setters and getters as extra functions in the keeper.
-* The implementation, in the keeper, of the storage getters as they come from the gRPC server.
+* The implementation in the keeper of the storage getters, as they come from the gRPC server.
 
-## Conclusion
+### Conclusion
 
-At this point, Starport got you covered, and you did not have to do much. Sure you had to confirm the correct genesis value of `NextGame.IdValue`.
+At this point, Starport got you covered and you did not have to do much. You confirmed the correct genesis value of `NextGame.IdValue`.

--- a/b9lab-content/5-my-own-chain/03-starport-04-create-message.md
+++ b/b9lab-content/5-my-own-chain/03-starport-04-create-message.md
@@ -1,0 +1,108 @@
+---
+title: The Create Game Message
+order: 6
+description: You create the message to create a game.
+---
+
+# The Create Game Message
+
+Now that your game objects have been defined in storage, and since you prevented, for good reason, a simple CRUD to set them, you need a message to instruct the keeper blockchain to create a game. What do you need it to expose?
+
+* It does not need to specify the creator. Or rather, this is implicit because this shall be the signer of the message.
+* It does not need to specify the id of the game because the system uses an incrementing counter. On the other hand, the server needs to return the newly created id value since the eventual value cannot be known before the transaction is included in a block and the state computed. Let's call this `idValue`.
+* It does not need to specify the game board as it is under the full control of the checkers rules.
+* It needs to specify who is playing reds, let's call the field: `red`.
+* It needs to specify who is playing blacks, let's call the field: `black`.
+
+That's not much, so again, let's instruct Starport to take care of all this:
+
+```sh
+$ starport scaffold message createGame red black --module checkers --response idValue
+```
+This has created a certain number of files as can be seen [here](https://github.com/cosmos/b9-checkers-academy-draft/commit/e78cba34926ba0adee23febb1ce44774e2c466b3), plus GUI elements seen [there](https://github.com/cosmos/b9-checkers-academy-draft/commit/dcf9f4724570146c8e0ad339aafb469d27dca0b9).
+
+## Protobuf Objects
+
+Again, it created simple Protobuf objects:
+
+```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/e78cba34926ba0adee23febb1ce44774e2c466b3/proto/checkers/tx.proto#L15-L23]
+message MsgCreateGame {
+    string creator = 1;
+    string red = 2;
+    string black = 3;
+}
+
+message MsgCreateGameResponse {
+    string idValue = 1;
+}
+```
+Which, when compiled yield:
+
+```go
+type MsgCreateGame struct {
+    Creator string `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
+    Red     string `protobuf:"bytes,2,opt,name=red,proto3" json:"red,omitempty"`
+    Black   string `protobuf:"bytes,3,opt,name=black,proto3" json:"black,omitempty"`
+}
+
+type MsgCreateGameResponse struct {
+    IdValue string `protobuf:"bytes,1,opt,name=idValue,proto3" json:"idValue,omitempty"`
+}
+```
+And the boilerplate to serialize the pair, which are files named `*.pb.go` that you should not edit. Starport also registered `MsgCreateGame` as a concrete message type with the two (de)serialization engines:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/e78cba34926ba0adee23febb1ce44774e2c466b3/x/checkers/types/codec.go#L14]
+func RegisterCodec(cdc *codec.LegacyAmino) {
+    cdc.RegisterConcrete(&MsgCreateGame{}, "checkers/CreateGame", nil)
+}
+```
+And
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/e78cba34926ba0adee23febb1ce44774e2c466b3/x/checkers/types/codec.go#L20-L22]
+func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+    registry.RegisterImplementations((*sdk.Msg)(nil),
+        &MsgCreateGame{},
+    )
+    ...
+}
+```
+Which is code that you probably need not change.
+
+Other boilerplate created by Starport is code to have the message conform to the `sdk.Msg` type like:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/e78cba34926ba0adee23febb1ce44774e2c466b3/x/checkers/types/message_create_game.go#L26-L32]
+func (msg *MsgCreateGame) GetSigners() []sdk.AccAddress {
+    creator, err := sdk.AccAddressFromBech32(msg.Creator)
+    if err != nil {
+        panic(err)
+    }
+    return []sdk.AccAddress{creator}
+}
+```
+This is code that is created only once and therefore that you can modify as you see fit.
+
+## Protobuf Service Interface
+
+Now, because this is a message that is meant to be sent and received, Starport also added a new function to your gRPC interface that receives all transaction messages for the module. This interface is called `service Msg` and is declared inside `proto/checkers/tx.proto`. Starport created this `tx.proto` file at the beginning when you created your project. This is Starport's modus operandi, it files different concerns into different files so that it knows where to add elements when you instruct it. That's what it did here, adding a function to the empty `service Msg`.
+
+The new function will receive this `MsgCreateGame`. Namely:
+
+```proto
+service Msg {
+    rpc CreateGame(MsgCreateGame) returns (MsgCreateGameResponse);
+}
+```
+As an interface it does not describe what should happen when called, though. What Starport does, with the help of Protobuf, is compile the interface and create a default Go implementation. Now, since you are responsible for what creating a game means, Starport separated concerns into different files. The most relevant for you at this point is `x/checkers/keeper/msg_server_create_game.go`. It is created once and this is where you need to code the creation of the game:
+
+```go
+func (k msgServer) CreateGame(goCtx context.Context, msg *types.MsgCreateGame) (*types.MsgCreateGameResponse, error) {
+    ctx := sdk.UnwrapSDKContext(goCtx)
+
+    // TODO: Handling the message
+    _ = ctx
+
+    return &types.MsgCreateGameResponse{}, nil
+}
+```
+
+<!-- Add GUI Elements -->

--- a/b9lab-content/5-my-own-chain/03-starport-04-create-message.md
+++ b/b9lab-content/5-my-own-chain/03-starport-04-create-message.md
@@ -6,9 +6,9 @@ description: You create the message to create a game.
 
 # The Create Game Message
 
-Now that your game objects have been defined in storage, and since you prevented, for good reason, a simple CRUD to set them, you need a message to instruct the keeper blockchain to create a game. What do you need it to expose?
+Now that your game objects have been defined in storage, and since you prevented, for good reason, a simple CRUD to set them, you need a message to instruct the checkers blockchain to create a game. What do you need it to expose?
 
-* It does not need to specify the creator. Or rather, this is implicit because this shall be the signer of the message.
+* It does not need to specify the creator. Or rather, this is implicit because it shall be the signer of the message.
 * It does not need to specify the id of the game because the system uses an incrementing counter. On the other hand, the server needs to return the newly created id value since the eventual value cannot be known before the transaction is included in a block and the state computed. Let's call this `idValue`.
 * It does not need to specify the game board as it is under the full control of the checkers rules.
 * It needs to specify who is playing reds, let's call the field: `red`.
@@ -25,7 +25,7 @@ This has created a certain number of files as can be seen [here](https://github.
 
 Again, it created simple Protobuf objects:
 
-```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/e78cba34926ba0adee23febb1ce44774e2c466b3/proto/checkers/tx.proto#L15-L23]
+```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/b3cf9ea4c554158e950bcfe58803e53eefc31090/proto/checkers/tx.proto#L15-L23]
 message MsgCreateGame {
     string creator = 1;
     string red = 2;
@@ -38,25 +38,28 @@ message MsgCreateGameResponse {
 ```
 Which, when compiled yield:
 
-```go
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/b3cf9ea4c554158e950bcfe58803e53eefc31090/x/checkers/types/tx.pb.go#L31-L35]
 type MsgCreateGame struct {
     Creator string `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
     Red     string `protobuf:"bytes,2,opt,name=red,proto3" json:"red,omitempty"`
     Black   string `protobuf:"bytes,3,opt,name=black,proto3" json:"black,omitempty"`
 }
+```
+And:
 
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/b3cf9ea4c554158e950bcfe58803e53eefc31090/x/checkers/types/tx.pb.go#L91-L93]
 type MsgCreateGameResponse struct {
     IdValue string `protobuf:"bytes,1,opt,name=idValue,proto3" json:"idValue,omitempty"`
 }
 ```
-And the boilerplate to serialize the pair, which are files named `*.pb.go` that you should not edit. Starport also registered `MsgCreateGame` as a concrete message type with the two (de)serialization engines:
+Plus the boilerplate to serialize the pair, which are files named `*.pb.go` that you should not edit. Starport also registered `MsgCreateGame` as a concrete message type with the two (de)serialization engines:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/e78cba34926ba0adee23febb1ce44774e2c466b3/x/checkers/types/codec.go#L14]
 func RegisterCodec(cdc *codec.LegacyAmino) {
     cdc.RegisterConcrete(&MsgCreateGame{}, "checkers/CreateGame", nil)
 }
 ```
-And
+And:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/e78cba34926ba0adee23febb1ce44774e2c466b3/x/checkers/types/codec.go#L20-L22]
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
@@ -87,14 +90,14 @@ Now, because this is a message that is meant to be sent and received, Starport a
 
 The new function will receive this `MsgCreateGame`. Namely:
 
-```proto
+```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/b3cf9ea4c554158e950bcfe58803e53eefc31090/proto/checkers/tx.proto#L11]
 service Msg {
     rpc CreateGame(MsgCreateGame) returns (MsgCreateGameResponse);
 }
 ```
-As an interface it does not describe what should happen when called, though. What Starport does, with the help of Protobuf, is compile the interface and create a default Go implementation. Now, since you are responsible for what creating a game means, Starport separated concerns into different files. The most relevant for you at this point is `x/checkers/keeper/msg_server_create_game.go`. It is created once and this is where you need to code the creation of the game:
+As an interface it does not describe what should happen when called, though. What Starport does, with the help of Protobuf, is compile the interface and create a default Go implementation. Now, since you are responsible for what creating a game means, Starport separated concerns into different files. The most relevant for you at this point is `x/checkers/keeper/msg_server_create_game.go`. It is created once and this is where you need to code the creation of the game proper:
 
-```go
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/e78cba34926ba0adee23febb1ce44774e2c466b3/x/checkers/keeper/msg_server_create_game.go#L10-L17]
 func (k msgServer) CreateGame(goCtx context.Context, msg *types.MsgCreateGame) (*types.MsgCreateGameResponse, error) {
     ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -104,5 +107,6 @@ func (k msgServer) CreateGame(goCtx context.Context, msg *types.MsgCreateGame) (
     return &types.MsgCreateGameResponse{}, nil
 }
 ```
+This is the object of the next section.
 
 <!-- Add GUI Elements -->

--- a/b9lab-content/5-my-own-chain/03-starport-04-create-message.md
+++ b/b9lab-content/5-my-own-chain/03-starport-04-create-message.md
@@ -25,7 +25,7 @@ This has created a certain number of files as can be seen [here](https://github.
 
 Again, it created simple Protobuf objects:
 
-```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/b3cf9ea4c554158e950bcfe58803e53eefc31090/proto/checkers/tx.proto#L15-L23]
+```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/b3cf9ea4c554158e950bcfe58803e53eefc31090/proto/checkers/tx.proto#L15-L23]
 message MsgCreateGame {
     string creator = 1;
     string red = 2;
@@ -90,7 +90,7 @@ Now, because this is a message that is meant to be sent and received, Starport a
 
 The new function will receive this `MsgCreateGame`. Namely:
 
-```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/b3cf9ea4c554158e950bcfe58803e53eefc31090/proto/checkers/tx.proto#L11]
+```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/b3cf9ea4c554158e950bcfe58803e53eefc31090/proto/checkers/tx.proto#L11]
 service Msg {
     rpc CreateGame(MsgCreateGame) returns (MsgCreateGameResponse);
 }

--- a/b9lab-content/5-my-own-chain/03-starport-05-create-handling.md
+++ b/b9lab-content/5-my-own-chain/03-starport-05-create-handling.md
@@ -1,18 +1,20 @@
 ---
-title: The Create Game Handling
+title: Create the Game Handling
 order: 7
-description: You create a game proper.
+description: You create a proper game
 ---
 
-# The Create Game Handling
+# Create the Game Handling
 
-In the previous section, you added the message to create a game. But that was just that, a message, along with its serialization and dedicated gRPC function. There remains to add the code that actually:
+In the [previous section](./03-starport-04-create-message), you added the message to create a game, along with its serialization and dedicated gRPC function.
+
+There remains to add code that actually:
 
 * Creates a brand new game.
 * Saves it in storage.
-* Returns the id of the new game.
+* Returns the ID of the new game.
 
-Given how Starport has separated its concerns, it has isolated this concern into its separate file, `x/checkers/keeper/msg_server_create_game.go`, for you to edit:
+Given Starport's seperation of concerns, it isolates this concern into a separate file, `x/checkers/keeper/msg_server_create_game.go`, for you to edit:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/e78cba34926ba0adee23febb1ce44774e2c466b3/x/checkers/keeper/msg_server_create_game.go#L10-L17]
 func (k msgServer) CreateGame(goCtx context.Context, msg *types.MsgCreateGame) (*types.MsgCreateGameResponse, error) {
@@ -24,11 +26,13 @@ func (k msgServer) CreateGame(goCtx context.Context, msg *types.MsgCreateGame) (
     return &types.MsgCreateGameResponse{}, nil
 }
 ```
-Now, it should be apparent to you why picking Starport was a shrewd move. All the message processing code was created for you and all you are left to do is the meaty part of the action.
 
-Given that you have already done a lot of the preparation work, let's see what that involves. Here `rules` represent the ready-made file with the rules of the game you imported:
+Now, all the message processing code was created for you and all you are left to do is code the action. As you can see, opting for Starport is a wise decision.
 
-* Get the new game's id:
+Given that you have already done a lot of preparatory work, what does it involve to code in the action? `rules` represent the ready-made file with the imported rules of the game:
+
+* Get the new game's ID:
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L15-L19]
     nextGame, found := k.Keeper.GetNextGame(ctx)
     if !found {
@@ -36,7 +40,8 @@ Given that you have already done a lot of the preparation work, let's see what t
     }
     newIndex := strconv.FormatUint(nextGame.IdValue, 10)
     ```
-* Create the object to store:
+* Create the object to be stored:
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L20-L26]
     storedGame := types.StoredGame{
         Creator: msg.Creator,
@@ -46,35 +51,45 @@ Given that you have already done a lot of the preparation work, let's see what t
         Black:   msg.Black,
     }
     ```
-* Confirm that the values in it are correct, in effect checking the validity of the players' addresses:
+
+* Confirm that the values in it are correct by checking the validity of the players' addresses:
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L27-L30]
     err := storedGame.Validate()
     if err != nil {
         return nil, err
     }
     ```
-* Save it:
+
+* Save the game:
+
+<!-- Are we saving the game or the address? Please be more precise. -->
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L31]
     k.Keeper.SetStoredGame(ctx, storedGame)
     ```
-* Prepare the ground for the next game:
+
+* Prepare the ground for the next game with:
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L33-L34]
     nextGame.IdValue++
     k.Keeper.SetNextGame(ctx, nextGame)
     ```
-* And return the newly created id for reference:
+
+* Return the newly created ID for reference:
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L36-L38]
     return &types.MsgCreateGameResponse{
         IdValue: newIndex,
     }, nil
     ```
 
-As you can see, proper preparation in the previous sections made this handling a breeze. In the next sections, you will modify this handling:
+As you can see, proper preparation in the previous sections made handling this a breeze. In the next sections, you will modify this handling:
 
 * To add new fields to the stored information.
 * To add an event.
 * To consume some gas.
-* To facilitate eventual deadline enforcement.
+* To facilitate the eventual deadline enforcement.
 * To add _money_ handling.
 
-With the game created, it's time to move to playing it.
+Now, that a game is created, it is time to play it.

--- a/b9lab-content/5-my-own-chain/03-starport-05-create-handling.md
+++ b/b9lab-content/5-my-own-chain/03-starport-05-create-handling.md
@@ -24,7 +24,7 @@ func (k msgServer) CreateGame(goCtx context.Context, msg *types.MsgCreateGame) (
     return &types.MsgCreateGameResponse{}, nil
 }
 ```
-Now, it should be apparent to you why picking Starport was shrewd. All the message processing code was created for you and all you are left to do is the meaty part of the action.
+Now, it should be apparent to you why picking Starport was a shrewd move. All the message processing code was created for you and all you are left to do is the meaty part of the action.
 
 Given that you have already done a lot of the preparation work, let's see what that involves. Here `rules` represent the ready-made file with the rules of the game you imported:
 
@@ -46,7 +46,7 @@ Given that you have already done a lot of the preparation work, let's see what t
         Black:   msg.Black,
     }
     ```
-* Confirm that the values in it are correct:
+* Confirm that the values in it are correct, in effect checking the validity of the players' addresses:
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L27-L30]
     err := storedGame.Validate()
     if err != nil {
@@ -58,12 +58,12 @@ Given that you have already done a lot of the preparation work, let's see what t
     k.Keeper.SetStoredGame(ctx, storedGame)
     ```
 * Prepare the ground for the next game:
-    ```go
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L33-L34]
     nextGame.IdValue++
     k.Keeper.SetNextGame(ctx, nextGame)
     ```
 * And return the newly created id for reference:
-    ```go []
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L36-L38]
     return &types.MsgCreateGameResponse{
         IdValue: newIndex,
     }, nil
@@ -75,5 +75,6 @@ As you can see, proper preparation in the previous sections made this handling a
 * To add an event.
 * To consume some gas.
 * To facilitate eventual deadline enforcement.
+* To add _money_ handling.
 
 With the game created, it's time to move to playing it.

--- a/b9lab-content/5-my-own-chain/03-starport-05-create-handling.md
+++ b/b9lab-content/5-my-own-chain/03-starport-05-create-handling.md
@@ -1,0 +1,79 @@
+---
+title: The Create Game Handling
+order: 7
+description: You create a game proper.
+---
+
+# The Create Game Handling
+
+In the previous section, you added the message to create a game. But that was just that, a message, along with its serialization and dedicated gRPC function. There remains to add the code that actually:
+
+* Creates a brand new game.
+* Saves it in storage.
+* Returns the id of the new game.
+
+Given how Starport has separated its concerns, it has isolated this concern into its separate file, `x/checkers/keeper/msg_server_create_game.go`, for you to edit:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/e78cba34926ba0adee23febb1ce44774e2c466b3/x/checkers/keeper/msg_server_create_game.go#L10-L17]
+func (k msgServer) CreateGame(goCtx context.Context, msg *types.MsgCreateGame) (*types.MsgCreateGameResponse, error) {
+    ctx := sdk.UnwrapSDKContext(goCtx)
+
+    // TODO: Handling the message
+    _ = ctx
+
+    return &types.MsgCreateGameResponse{}, nil
+}
+```
+Now, it should be apparent to you why picking Starport was shrewd. All the message processing code was created for you and all you are left to do is the meaty part of the action.
+
+Given that you have already done a lot of the preparation work, let's see what that involves. Here `rules` represent the ready-made file with the rules of the game you imported:
+
+* Get the new game's id:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L15-L19]
+    nextGame, found := k.Keeper.GetNextGame(ctx)
+    if !found {
+        panic("NextGame not found")
+    }
+    newIndex := strconv.FormatUint(nextGame.IdValue, 10)
+    ```
+* Create the object to store:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L20-L26]
+    storedGame := types.StoredGame{
+        Creator: msg.Creator,
+        Index:   newIndex,
+        Game:    rules.New().String(),
+        Red:     msg.Red,
+        Black:   msg.Black,
+    }
+    ```
+* Confirm that the values in it are correct:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L27-L30]
+    err := storedGame.Validate()
+    if err != nil {
+        return nil, err
+    }
+    ```
+* Save it:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/d59a74496a96018c57fdff72c443980c08416499/x/checkers/keeper/msg_server_create_game.go#L31]
+    k.Keeper.SetStoredGame(ctx, storedGame)
+    ```
+* Prepare the ground for the next game:
+    ```go
+    nextGame.IdValue++
+    k.Keeper.SetNextGame(ctx, nextGame)
+    ```
+* And return the newly created id for reference:
+    ```go []
+    return &types.MsgCreateGameResponse{
+        IdValue: newIndex,
+    }, nil
+    ```
+
+As you can see, proper preparation in the previous sections made this handling a breeze. In the next sections, you will modify this handling:
+
+* To add new fields to the stored information.
+* To add an event.
+* To consume some gas.
+* To facilitate eventual deadline enforcement.
+
+With the game created, it's time to move to playing it.

--- a/b9lab-content/5-my-own-chain/03-starport-06-play-game.md
+++ b/b9lab-content/5-my-own-chain/03-starport-06-play-game.md
@@ -28,7 +28,7 @@ $ starport scaffold message playMove idValue fromX:uint fromY:uint toX:uint toY:
 Once more, Starport has created all the necessary Protobuf files and the boilerplate for you. All you are left to do is:
 
 * Add to `proto/checkers/tx.proto`:
-    ```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc4feaf38687092712849f35a5d74a11378/proto/checkers/tx.proto#L25-L30]
+    ```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc4feaf38687092712849f35a5d74a11378/proto/checkers/tx.proto#L25-L30]
     message MsgPlayMoveResponse {
         string idValue = 1;
         int64 capturedX = 2;

--- a/b9lab-content/5-my-own-chain/03-starport-06-play-game.md
+++ b/b9lab-content/5-my-own-chain/03-starport-06-play-game.md
@@ -12,7 +12,7 @@ In order to see in details what Starport would create, refer back to [The Create
 * The initial position of the pawn to play. Let's call the fields `fromX` and `fromY`.
 * The final position of the pawn to play. Let's call the fields `toX` and `toY`.
 
-The player need not be made explicitly as a field in the message because implicitly it is the signer of the message. Let's name the object `PlayMove`. Now, unlike when creating the game, here you may want to return more than just a game id. In particular:
+The player need not be made explicit as a field in the message because, implicitly, it is the signer of the message. Let's name the object `PlayMove`. Now, unlike when creating the game, here you may want to return more than just a game id. In particular:
 
 * The game id. Let's call the field `idValue` too.
 * A potential captured piece. Let's call the fields `capturedX` and `capturedY`.
@@ -22,7 +22,7 @@ The player need not be made explicitly as a field in the message because implici
 
 Now, Starport only creates a response object with a single field. Not to worry, you can update the object after Starport has run. Therefore:
 
-```go
+```sh
 $ starport scaffold message playMove idValue fromX:uint fromY:uint toX:uint toY:uint --module checkers --response idValue
 ```
 Once more, Starport has created all the necessary Protobuf files and the boilerplate for you. All you are left to do is:
@@ -48,11 +48,11 @@ Once more, Starport has created all the necessary Protobuf files and the boilerp
     }
     ```
 
-You start getting the hang of it.
+You should start getting the hang of it.
 
 ## The Move Handling Part
 
-Below `rules` represent the ready-made file with the rules of the game you imported. And the following errors have been declared in `x/checkers/types/errors.go`:
+Below, `rules` represent the ready-made file with the rules of the game you imported earlier. And the following errors have been declared in `x/checkers/types/errors.go`:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc4feaf38687092712849f35a5d74a11378/x/checkers/types/errors.go#L14-L18]
 ErrGameNotFound     = sdkerrors.Register(ModuleName, 1104, "game by id not found: %s")
@@ -60,7 +60,6 @@ ErrCreatorNotPlayer = sdkerrors.Register(ModuleName, 1105, "message creator is n
 ErrNotPlayerTurn    = sdkerrors.Register(ModuleName, 1106, "player tried to play out of turn: %s")
 ErrWrongMove        = sdkerrors.Register(ModuleName, 1107, "wrong move")
 ```
-
 The steps are none other than:
 
 * Fetch the stored game information:
@@ -110,7 +109,7 @@ The steps are none other than:
         return nil, sdkerrors.Wrapf(moveErr, types.ErrWrongMove.Error())
     }
     ```
-* Prepare the board to be stored store, and store the information:
+* Prepare the updated board to be stored, and store the information:
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L56-L58]
     storedGame.Game = game.String()
     storedGame.Turn = game.Turn.Color

--- a/b9lab-content/5-my-own-chain/03-starport-06-play-game.md
+++ b/b9lab-content/5-my-own-chain/03-starport-06-play-game.md
@@ -1,0 +1,129 @@
+---
+title: The Play Game Elements
+order: 8
+description: You play a game.
+---
+
+# The Play Game Elements
+
+In order to see in details what Starport would create, refer back to [The Create Game Message](./03-starport-04-create-message). Here, it is sufficient to say that to play a game, a player only needs to specify:
+
+* The id of the game to play in. Let's call the field `idValue`.
+* The initial position of the pawn to play. Let's call the fields `fromX` and `fromY`.
+* The final position of the pawn to play. Let's call the fields `toX` and `toY`.
+
+The player need not be made explicitly as a field in the message because implicitly it is the signer of the message. Let's name the object `PlayMove`. Now, unlike when creating the game, here you may want to return more than just a game id. In particular:
+
+* The game id. Let's call the field `idValue` too.
+* A potential captured piece. Let's call the fields `capturedX` and `capturedY`.
+* A potential winner. Let's call the field `winner`.
+
+## With Starport
+
+Now, Starport only creates a response object with a single field. Not to worry, you can update the object after Starport has run. Therefore:
+
+```go
+$ starport scaffold message playMove idValue fromX:uint fromY:uint toX:uint toY:uint --module checkers --response idValue
+```
+Once more, Starport has created all the necessary Protobuf files and the boilerplate for you. All you are left to do is:
+
+* Add to `proto/checkers/tx.proto`:
+    ```proto [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc4feaf38687092712849f35a5d74a11378/proto/checkers/tx.proto#L25-L30]
+    message MsgPlayMoveResponse {
+        string idValue = 1;
+        int64 capturedX = 2;
+        int64 capturedY = 3;
+        string winner = 4;
+    }
+    ```
+* Fill in the meaty part in `x/checkers/keeper/msg_server_play_move.go`:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/f52a673c3fbd2c31c408f0c0aecb70d8c1a880f7/x/checkers/keeper/msg_server_play_move.go#L10-L17]
+    func (k msgServer) PlayMove(goCtx context.Context, msg *types.MsgPlayMove) (*types.MsgPlayMoveResponse, error) {
+        ctx := sdk.UnwrapSDKContext(goCtx)
+
+        // TODO: Handling the message
+        _ = ctx
+
+        return &types.MsgPlayMoveResponse{}, nil
+    }
+    ```
+
+You start getting the hang of it.
+
+## The Move Handling Part
+
+Below `rules` represent the ready-made file with the rules of the game you imported. And the following errors have been declared in `x/checkers/types/errors.go`:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc4feaf38687092712849f35a5d74a11378/x/checkers/types/errors.go#L14-L18]
+ErrGameNotFound     = sdkerrors.Register(ModuleName, 1104, "game by id not found: %s")
+ErrCreatorNotPlayer = sdkerrors.Register(ModuleName, 1105, "message creator is not a player: %s")
+ErrNotPlayerTurn    = sdkerrors.Register(ModuleName, 1106, "player tried to play out of turn: %s")
+ErrWrongMove        = sdkerrors.Register(ModuleName, 1107, "wrong move")
+```
+
+The steps are none other than:
+
+* Fetch the stored game information:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L16-L19]
+    storedGame, found := k.Keeper.GetStoredGame(ctx, msg.IdValue)
+    if !found {
+        return nil, sdkerrors.Wrapf(types.ErrGameNotFound, "game not found %s", msg.IdValue)
+    }
+    ```
+* Is the player legitimate:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L22-L29]
+    var player rules.Player
+    if strings.Compare(storedGame.Red, msg.Creator) == 0 {
+        player = rules.RED_PLAYER
+    } else if strings.Compare(storedGame.Black, msg.Creator) == 0 {
+        player = rules.BLACK_PLAYER
+    } else {
+        return nil, types.ErrCreatorNotPlayer
+    }
+    ```
+* Instantiate the board so that we can use rules:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L32-L35]
+    game, err := storedGame.ParseGame()
+    if err != nil {
+        panic(err.Error())
+    }
+    ```
+* Is it the player's turn:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L36-L38]
+    if !game.TurnIs(player) {
+        return nil, types.ErrNotPlayerTurn
+    }
+    ```
+* All good, do the move proper:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L41-L53]
+    captured, moveErr := game.Move(
+        rules.Pos{
+            X: int(msg.FromX),
+            Y: int(msg.FromY),
+        },
+        rules.Pos{
+            X: int(msg.ToX),
+            Y: int(msg.ToY),
+        },
+    )
+    if moveErr != nil {
+        return nil, sdkerrors.Wrapf(moveErr, types.ErrWrongMove.Error())
+    }
+    ```
+* Prepare the board to be stored store, and store the information:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L56-L58]
+    storedGame.Game = game.String()
+    storedGame.Turn = game.Turn.Color
+    k.Keeper.SetStoredGame(ctx, storedGame)
+    ```
+* Return relevant information about the result of the move:
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L61-L66]
+    return &types.MsgPlayMoveResponse{
+        IdValue:   msg.IdValue,
+        CapturedX: int64(captured.X),
+        CapturedY: int64(captured.Y),
+        Winner:    game.Winner().Color,
+    }, nil
+    ```
+
+And that's all there is to it. Good preparation and the use of Starport yield rewards.

--- a/b9lab-content/5-my-own-chain/03-starport-06-play-game.md
+++ b/b9lab-content/5-my-own-chain/03-starport-06-play-game.md
@@ -6,28 +6,38 @@ description: You play a game.
 
 # The Play Game Elements
 
-In order to see in details what Starport would create, refer back to [The Create Game Message](./03-starport-04-create-message). Here, it is sufficient to say that to play a game, a player only needs to specify:
+<HighlightBox type="tip">
 
-* The id of the game to play in. Let's call the field `idValue`.
-* The initial position of the pawn to play. Let's call the fields `fromX` and `fromY`.
-* The final position of the pawn to play. Let's call the fields `toX` and `toY`.
+To see in detail what Starport creates, refer back to [Creating the Game Message](./03-starport-04-create-message). Here, it is sufficient to specify some aspects.
 
-The player need not be made explicit as a field in the message because, implicitly, it is the signer of the message. Let's name the object `PlayMove`. Now, unlike when creating the game, here you may want to return more than just a game id. In particular:
+</HighlightBox>
 
-* The game id. Let's call the field `idValue` too.
-* A potential captured piece. Let's call the fields `capturedX` and `capturedY`.
-* A potential winner. Let's call the field `winner`.
+To play a game, a player only needs to specify:
+
+* The ID of the game the player wants to join. Let's call the field `idValue`.
+* The initial positions of the pawns. Let's call the fields `fromX` and `fromY`.
+* The final position of the pawns after a player's move. Let's call the fields `toX` and `toY`.
+
+The player does not need to be explicitly a field in the message because, implicitly, it is the signer of the message. Let's name the object `PlayMove`.
+
+Unlike when creating the game, you may want to return more than just a game ID. You might want to return:
+
+* The game ID. Let's also call this field `idValue`.
+* The captured piece. Let's call the fields `capturedX` and `capturedY`.
+* The winner, in the field `winner`.
 
 ## With Starport
 
-Now, Starport only creates a response object with a single field. Not to worry, you can update the object after Starport has run. Therefore:
+Now, Starport only creates a response object with a single field. You can update the object after Starport has run:
 
 ```sh
 $ starport scaffold message playMove idValue fromX:uint fromY:uint toX:uint toY:uint --module checkers --response idValue
 ```
-Once more, Starport has created all the necessary Protobuf files and the boilerplate for you. All you are left to do is:
+
+Once more, Starport creates all the necessary Protobuf files and the boilerplate for you. All you have left to do is:
 
 * Add to `proto/checkers/tx.proto`:
+
     ```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc4feaf38687092712849f35a5d74a11378/proto/checkers/tx.proto#L25-L30]
     message MsgPlayMoveResponse {
         string idValue = 1;
@@ -36,7 +46,9 @@ Once more, Starport has created all the necessary Protobuf files and the boilerp
         string winner = 4;
     }
     ```
-* Fill in the meaty part in `x/checkers/keeper/msg_server_play_move.go`:
+
+* Fill in the needed part in `x/checkers/keeper/msg_server_play_move.go`:
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/f52a673c3fbd2c31c408f0c0aecb70d8c1a880f7/x/checkers/keeper/msg_server_play_move.go#L10-L17]
     func (k msgServer) PlayMove(goCtx context.Context, msg *types.MsgPlayMove) (*types.MsgPlayMoveResponse, error) {
         ctx := sdk.UnwrapSDKContext(goCtx)
@@ -48,11 +60,9 @@ Once more, Starport has created all the necessary Protobuf files and the boilerp
     }
     ```
 
-You should start getting the hang of it.
+## The move handling
 
-## The Move Handling Part
-
-Below, `rules` represent the ready-made file with the rules of the game you imported earlier. And the following errors have been declared in `x/checkers/types/errors.go`:
+`rules` represent the ready-made file with the rules of the game you imported earlier. The following errors have been declared in `x/checkers/types/errors.go`:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc4feaf38687092712849f35a5d74a11378/x/checkers/types/errors.go#L14-L18]
 ErrGameNotFound     = sdkerrors.Register(ModuleName, 1104, "game by id not found: %s")
@@ -60,16 +70,20 @@ ErrCreatorNotPlayer = sdkerrors.Register(ModuleName, 1105, "message creator is n
 ErrNotPlayerTurn    = sdkerrors.Register(ModuleName, 1106, "player tried to play out of turn: %s")
 ErrWrongMove        = sdkerrors.Register(ModuleName, 1107, "wrong move")
 ```
-The steps are none other than:
 
-* Fetch the stored game information:
+The steps are:
+
+1. Fetch the stored game information:
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L16-L19]
     storedGame, found := k.Keeper.GetStoredGame(ctx, msg.IdValue)
     if !found {
         return nil, sdkerrors.Wrapf(types.ErrGameNotFound, "game not found %s", msg.IdValue)
     }
     ```
-* Is the player legitimate:
+
+2. Is the player legitimate?
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L22-L29]
     var player rules.Player
     if strings.Compare(storedGame.Red, msg.Creator) == 0 {
@@ -80,20 +94,26 @@ The steps are none other than:
         return nil, types.ErrCreatorNotPlayer
     }
     ```
-* Instantiate the board so that we can use rules:
+
+3. Instantiate the board to implement the rules:
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L32-L35]
     game, err := storedGame.ParseGame()
     if err != nil {
         panic(err.Error())
     }
     ```
-* Is it the player's turn:
+
+4. Is it the player's turn?
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L36-L38]
     if !game.TurnIs(player) {
         return nil, types.ErrNotPlayerTurn
     }
     ```
-* All good, do the move proper:
+
+5. Properly conduct the move:
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L41-L53]
     captured, moveErr := game.Move(
         rules.Pos{
@@ -109,13 +129,16 @@ The steps are none other than:
         return nil, sdkerrors.Wrapf(moveErr, types.ErrWrongMove.Error())
     }
     ```
-* Prepare the updated board to be stored, and store the information:
+
+6. Prepare the updated board to be stored, and store the information:
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L56-L58]
     storedGame.Game = game.String()
     storedGame.Turn = game.Turn.Color
     k.Keeper.SetStoredGame(ctx, storedGame)
     ```
-* Return relevant information about the result of the move:
+7. Return relevant information regarding the move's result:
+
     ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/8d686fc/x/checkers/keeper/msg_server_play_move.go#L61-L66]
     return &types.MsgPlayMoveResponse{
         IdValue:   msg.IdValue,
@@ -125,4 +148,4 @@ The steps are none other than:
     }, nil
     ```
 
-And that's all there is to it. Good preparation and the use of Starport yield rewards.
+That is all there is to it: good preparation and the use of Starport yield rewards.

--- a/b9lab-content/5-my-own-chain/03-starport-07-events.md
+++ b/b9lab-content/5-my-own-chain/03-starport-07-events.md
@@ -1,26 +1,28 @@
 ---
 title: Adding Events
 order: 9
-description: Inform your players.
+description: Inform your players
 ---
 
 # Adding Events
 
-Now that you have added the possible actions, including their return values, it would be welcome to use the events system in order to alert players. You can imagine that a potential or current player is there, waiting for their turn. It is not practical to look at all transactions and find the relevant ones that signify "that's my turn". Better instead to listen to known events that tell the same.
+Now that you have [added the possible actions](./03-starport-06-play-game.md), including their return values, use events to alert/notify players.
 
-That's where events come in. Adding events to your application is as simple as:
+Imagine a potential or current player waiting for their turn. It is not practical to look at all the transactions and search for the ones signifying the player's turn. It is better to instead listen to known events that let determine whose player's turn it is.
+
+This is where events come in. Adding events to your application is as simple as:
 
 1. Defining the events you want to use.
 2. Emitting them at the right locations.
 
-## Game Created Event
+## Game created event
 
-Let's start with the event that informs that a new game has been created. The goal is to:
+Let's start with the event that announces the creation of a new game. The goal is to:
 
-* Inform / alert the concerned players.
-* Make it easy for them to find the relevant game.
+* Inform/alert the concerned players (the players of the game).
+* Make it easy for the players to find the relevant game.
 
-So, you define some new keys in `x/checkers/types/keys.go`:
+So, define some new keys in `x/checkers/types/keys.go`:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/f5764b84452983bc85e59823302464723df02f9a/x/checkers/types/keys.go#L34-L39]
 const (
@@ -31,7 +33,8 @@ const (
     StoredGameEventBlack   = "Black" // Is it relevant to me?
 )
 ```
-And emit the event in your file `x/checkers/keeper/msg_server_create_game.go`:
+
+Emit the event in your file `x/checkers/keeper/msg_server_create_game.go`:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/f5764b84452983bc85e59823302464723df02f9a/x/checkers/keeper/msg_server_create_game.go#L37-L46]
 ctx.EventManager().EmitEvent(
@@ -45,20 +48,22 @@ ctx.EventManager().EmitEvent(
     ),
 )
 ```
-There is not much more to it. What would need to be done is the counterpart of this in the GUI, or a server that listens for such events.
 
-## Player Moved Event
+The only thing left to do is to implement this correspondingly in the GUI or include a server listening for such events.
+
+## Player moved event
 
 Since you also created a transaction to play a move, it is expected to inform the opponent about:
 
 * Which player is relevant.
-* Which game this is about.
-* When such a move has happened, and what its outcome was.
-* Whether the game has been won.
+* Which game does the move relate to.
+* When the move happened.
+* What the move's outcome was.
+* Whether the game was won.
 
-Contrary to the create-game event, the players are already informed as to which game ids to watch out for. So there is no need to repeat the player addresses. Instead, the game id is information enough.
+Contrary to the "create game" event, the players know which game IDs to keep an eye out for. So, there is no need to repeat the players' addresses. The game ID is information enough.
 
-So, similarly, you define new keys in `x/checkers/types/keys.go`:
+Similarly, you define new keys in `x/checkers/types/keys.go`:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/f5764b84452983bc85e59823302464723df02f9a/x/checkers/types/keys.go#L41-L48]
 const (
@@ -70,7 +75,8 @@ const (
     PlayMoveEventWinner    = "Winner"
 )
 ```
-And emit the event in your file `x/checkers/keeper/msg_server_play_move.go`:
+
+Emit the event in your file `x/checkers/keeper/msg_server_play_move.go`:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/f5764b84452983bc85e59823302464723df02f9a/x/checkers/keeper/msg_server_play_move.go#L62-L72]
 ctx.EventManager().EmitEvent(
@@ -85,4 +91,5 @@ ctx.EventManager().EmitEvent(
     ),
 )
 ```
-And that's it. You have emitted two events that inform external systems of step changes in the lifecycle of a game. Time to make it possible for a player to reject a game.
+
+That is it: you have emitted two events that inform external systems of step changes in the lifecycle of a game. Time to make it possible for a player to reject a game.

--- a/b9lab-content/5-my-own-chain/03-starport-07-events.md
+++ b/b9lab-content/5-my-own-chain/03-starport-07-events.md
@@ -1,0 +1,89 @@
+---
+title: Adding Events
+order: 9
+description: Inform your players.
+---
+
+# Adding Events
+
+Now that you have added the possible actions, including their return values, it would be welcome to use the events system in order to alert players. You can imagine that a potential or current player is there, waiting for their turn. It is not practical to look at all transactions and find the relevant ones that signify "that's my turn". Better instead to listen to known events that tell the same.
+
+That's where events come in. Adding events to your application is as simple as:
+
+1. Defining the events you want to use.
+2. Emit them at the right locations.
+
+## Game Created Event
+
+Let's start with the event that informs that a new game has been created. The goal is to:
+
+* Inform / alert the concerned players.
+* Make it easy for them to find the relevant game.
+
+So, you define some new keys in `x/checkers/types/keys.go`:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/f5764b84452983bc85e59823302464723df02f9a/x/checkers/types/keys.go#L34-L39]
+const (
+    StoredGameEventKey     = "NewGameCreated" // Indicates what key to listen to
+    StoredGameEventCreator = "Creator"
+    StoredGameEventIndex   = "Index" // What game is relevant
+    StoredGameEventRed     = "Red" // Is it relevant to me?
+    StoredGameEventBlack   = "Black" // Is it relevant to me?
+)
+```
+And emit the event in your file `x/checkers/keeper/msg_server_create_game.go`:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/f5764b84452983bc85e59823302464723df02f9a/x/checkers/keeper/msg_server_create_game.go#L37-L46]
+ctx.EventManager().EmitEvent(
+    sdk.NewEvent(sdk.EventTypeMessage,
+        sdk.NewAttribute(sdk.AttributeKeyModule, "checkers"),
+        sdk.NewAttribute(sdk.AttributeKeyAction, types.StoredGameEventKey),
+        sdk.NewAttribute(types.StoredGameEventCreator, msg.Creator),
+        sdk.NewAttribute(types.StoredGameEventIndex, newIndex),
+        sdk.NewAttribute(types.StoredGameEventRed, msg.Red),
+        sdk.NewAttribute(types.StoredGameEventBlack, msg.Black),
+    ),
+)
+```
+There is not much more to it. What would need to be done is the counterpart of this in the GUI, or a server that listens for such events.
+
+## Player Moved Event
+
+Since you also created a transaction to play a move, it is expected to inform the opponent about:
+
+* Alerting the relevant player.
+* Which game this is about.
+* When such a move has happened, and what its outcome was.
+* Whether the game has been won.
+
+Contrary to the create-game event, the players are already informed as to which game ids to watch out for. So there is no need to repeat the player addresses. Instead, the game id is information enough.
+
+So, similarly, you define new keys in `x/checkers/types/keys.go`:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/f5764b84452983bc85e59823302464723df02f9a/x/checkers/types/keys.go#L41-L48]
+const (
+    PlayMoveEventKey       = "MovePlayed"
+    PlayMoveEventCreator   = "Creator"
+    PlayMoveEventIdValue   = "IdValue"
+    PlayMoveEventCapturedX = "CapturedX"
+    PlayMoveEventCapturedY = "CapturedY"
+    PlayMoveEventWinner    = "Winner"
+)
+```
+
+And emit the event in your file `x/checkers/keeper/msg_server_play_move.go`:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/f5764b84452983bc85e59823302464723df02f9a/x/checkers/keeper/msg_server_play_move.go#L62-L72]
+ctx.EventManager().EmitEvent(
+     sdk.NewEvent(sdk.EventTypeMessage,
+        sdk.NewAttribute(sdk.AttributeKeyModule, "checkers"),
+        sdk.NewAttribute(sdk.AttributeKeyAction, types.PlayMoveEventKey),
+        sdk.NewAttribute(types.PlayMoveEventCreator, msg.Creator),
+        sdk.NewAttribute(types.PlayMoveEventIdValue, msg.IdValue),
+        sdk.NewAttribute(types.PlayMoveEventCapturedX, strconv.FormatInt(int64(captured.X), 10)),
+        sdk.NewAttribute(types.PlayMoveEventCapturedY, strconv.FormatInt(int64(captured.Y), 10)),
+        sdk.NewAttribute(types.PlayMoveEventWinner, game.Winner().Color),
+    ),
+)
+```
+And that's it. You have emitted two events that inform external systems of step changes in the lifecycle of a game. Time to make it possible for a player to reject a game.

--- a/b9lab-content/5-my-own-chain/03-starport-07-events.md
+++ b/b9lab-content/5-my-own-chain/03-starport-07-events.md
@@ -11,7 +11,7 @@ Now that you have added the possible actions, including their return values, it 
 That's where events come in. Adding events to your application is as simple as:
 
 1. Defining the events you want to use.
-2. Emit them at the right locations.
+2. Emitting them at the right locations.
 
 ## Game Created Event
 
@@ -51,7 +51,7 @@ There is not much more to it. What would need to be done is the counterpart of t
 
 Since you also created a transaction to play a move, it is expected to inform the opponent about:
 
-* Alerting the relevant player.
+* Which player is relevant.
 * Which game this is about.
 * When such a move has happened, and what its outcome was.
 * Whether the game has been won.
@@ -70,7 +70,6 @@ const (
     PlayMoveEventWinner    = "Winner"
 )
 ```
-
 And emit the event in your file `x/checkers/keeper/msg_server_play_move.go`:
 
 ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/f5764b84452983bc85e59823302464723df02f9a/x/checkers/keeper/msg_server_play_move.go#L62-L72]


### PR DESCRIPTION
Docs content update for Module 5, Section _Starport_ - part of the [b9lab-content](https://github.com/cosmos/sdk-tutorials/tree/master/b9lab-content).

This PR adds code samples to the content. The code shown here is taken from the [code example repo](https://github.com/cosmos/b9-checkers-academy-draft/) and has been hardly adjusted. The repo has been reviewed so no need to review it here. What we are looking for is to make sure that the introductory texts are not misleading or even downright wrong.

The Starport code sample integration PRs are split into three parts, also see #852 and #854

### Content state

**✔️ Completed**

### Technical review
- [x] requested
- [ ] completed

### Language review
- [ ] requested
- [ ] completed