### PR TITLE
Voter tutorial update

### DIFF
--- a/voter/voter/app/app.go
+++ b/voter/voter/app/app.go
@@ -151,6 +151,7 @@ var (
 		stakingtypes.NotBondedPoolName: {authtypes.Burner, authtypes.Staking},
 		govtypes.ModuleName:            {authtypes.Burner},
 		ibctransfertypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
+		votermoduletypes.ModuleName:    {authtypes.Minter, authtypes.Burner, authtypes.Staking},
 		// this line is used by starport scaffolding # stargate/app/maccPerms
 	}
 )

--- a/voter/voter/x/voter/keeper/msg_server_poll.go
+++ b/voter/voter/x/voter/keeper/msg_server_poll.go
@@ -7,13 +7,11 @@ import (
 	"github.com/cosmonaut/voter/x/voter/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/tendermint/tendermint/crypto"
 )
 
 func (k msgServer) CreatePoll(goCtx context.Context, msg *types.MsgCreatePoll) (*types.MsgCreatePollResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	moduleAcct := sdk.AccAddress(crypto.AddressHash([]byte(types.ModuleName)))
 	feeCoins, err := sdk.ParseCoinsNormalized("200token")
 	if err != nil {
 		return nil, err
@@ -23,7 +21,7 @@ func (k msgServer) CreatePoll(goCtx context.Context, msg *types.MsgCreatePoll) (
 	if err != nil {
 		return nil, err
 	}
-	if err := k.bankKeeper.SendCoins(ctx, creatorAddress, moduleAcct, feeCoins); err != nil {
+	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, creatorAddress, types.ModuleName, feeCoins); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
### Voter Tutorial Update
This update is a small change to the Voter Tutorial content.
It aims to use the dedicated functions of the Cosmos-SDK as much as possible.
The resulting should benefits to the learning experience of the tutorial.

The changes taken are:
 - Add the voter module name to the account module permissions
 - Use the dedicated method to send coins from an account to a module account

By doing so, the recipient account is of module account type rather
than base account type. Therefore, this update should also add more consistency
to the module transaction logic.