### PR TITLE
GitHub Developers Portal issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/devportal-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/devportal-bug-report.md
@@ -1,0 +1,28 @@
+---
+name: Developers Portal bug report
+about: Create a report to help us improve
+title: ''
+labels: report
+assignees: ''
+
+---
+
+Thank you for helping us improve the Cosmos Developers Portal. 
+
+Use this form to submit a bug report for the Developers Portal in general (broken link, missing content, navigation, and so on). 
+
+To submit a bug report for a specific tutorial, use [Cosmos SDK tutorials bug report](tutorials-bug-report.md).
+
+**What is the specific Developers Portal page?**
+Paste the URL here.
+
+**Describe the bug**
+Describe the bug. Tell us about your challenges. A clear and concise description helps us identify and understand the issue. Take a screen capture if that helps. 
+
+**To reproduce**
+Steps to reproduce the issue:
+1. 
+
+
+**Solution**
+Do you have a solution? Great. Describe it here or even better, see [CONTRIBUTING.md](https://github.com/cosmos/sdk-tutorials/blob/master/CONTRIBUTING.md) and make a direct contribution. Feel free to submit a PR. 

--- a/.github/ISSUE_TEMPLATE/devportal-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/devportal-bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: Developers Portal bug report
+name: Developer Portal bug report
 about: Create a report to help us improve
 title: ''
 labels: report

--- a/.github/ISSUE_TEMPLATE/devportal-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/devportal-bug-report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 Thank you for helping us improve the Cosmos Developer Portal. 
 
-Use this form to submit a bug report for the Developers Portal in general (broken link, missing content, navigation, and so on). 
+Use this form to submit a bug report for the Developer Portal in general (broken link, missing content, navigation, and so on). 
 
 To submit a bug report for a specific tutorial, use [Cosmos SDK tutorials bug report](tutorials-bug-report.md).
 

--- a/.github/ISSUE_TEMPLATE/devportal-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/devportal-bug-report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Thank you for helping us improve the Cosmos Developers Portal. 
+Thank you for helping us improve the Cosmos Developer Portal. 
 
 Use this form to submit a bug report for the Developers Portal in general (broken link, missing content, navigation, and so on). 
 

--- a/.github/ISSUE_TEMPLATE/devportal-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/devportal-bug-report.md
@@ -13,7 +13,7 @@ Use this form to submit a bug report for the Developer Portal in general (broken
 
 To submit a bug report for a specific tutorial, use [Cosmos SDK tutorials bug report](tutorials-bug-report.md).
 
-**What is the specific Developers Portal page?**
+**What is the specific Developer Portal page?**
 Paste the URL here.
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/devportal-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/devportal-feature-request.md
@@ -9,7 +9,7 @@ assignees: ''
 
 Thank you for helping us improve the Cosmos Developer Portal. 
 
-Use this form to submit a feature request for the Developers Portal in general. 
+Use this form to submit a feature request for the Developer Portal in general. 
 
 To submit a feature request for a specific tutorial, use [Cosmos SDK tutorials feature request](tutorials-feature-request.md).
 

--- a/.github/ISSUE_TEMPLATE/devportal-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/devportal-feature-request.md
@@ -1,0 +1,23 @@
+---
+name: Developers Portal feature request
+about: Suggest a feature, improvement, or idea.
+title: ''
+labels: request
+assignees: ''
+
+---
+
+Thank you for helping us improve the Cosmos Developers Portal. 
+
+Use this form to submit a feature request for the Developers Portal in general. 
+
+To submit a feature request for a specific tutorial, use [Cosmos SDK tutorials feature request](tutorials-feature-request.md).
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Explain your friction point. For example, I'm always frustrated when [...]
+
+**Describe the solution you'd like to see**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/devportal-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/devportal-feature-request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Thank you for helping us improve the Cosmos Developers Portal. 
+Thank you for helping us improve the Cosmos Developer Portal. 
 
 Use this form to submit a feature request for the Developers Portal in general. 
 

--- a/.github/ISSUE_TEMPLATE/devportal-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/devportal-feature-request.md
@@ -1,5 +1,5 @@
 ---
-name: Developers Portal feature request
+name: Developer Portal feature request
 about: Suggest a feature, improvement, or idea.
 title: ''
 labels: request

--- a/.github/ISSUE_TEMPLATE/tutorials-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/tutorials-bug-report.md
@@ -11,7 +11,7 @@ Thank you for helping us improve Cosmos SDK tutorials.
 
 Use this form to submit a bug report for a specific tutorial. 
 
-To submit a bug report for the Developers Portal in general, use [Developers Portal bug report](devportal-bug-report.md).
+To submit a bug report for the Developer Portal in general, use [Developer Portal bug report](devportal-bug-report.md).
 
 **What tutorial are you working in?**
 Paste the URL of the Cosmos SDK tutorial.

--- a/.github/ISSUE_TEMPLATE/tutorials-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/tutorials-bug-report.md
@@ -7,20 +7,38 @@ assignees: ''
 
 ---
 
+Thank you for helping us improve Cosmos SDK tutorials. 
+
+Use this form to submit a bug report for a specific tutorial. 
+
+To submit a bug report for the Developers Portal in general, use [Developers Portal bug report](devportal-bug-report.md).
+
 **What tutorial are you working in?**
-Paste the URL of the tutorial.
+Paste the URL of the Cosmos SDK tutorial.
 
 **Describe the bug**
-Tell us about your challenges. A clear and concise description of your problem helps us reproduce the issue. 
+Tell us about your challenges. A clear and concise description of your problem helps us reproduce the issue. You can even provide a video or screenshot as needed. 
 
 **To reproduce**
 Steps to reproduce the behavior:
 1. 
 
-**Include the output of these commands**
- - If you are using Starport: `starport version`
- - `go version`
- - `uname -a`
+**What versions of software are you running?**
+
+What is your version of the Cosmos SDK? 
+
+Include the output of these commands.
+
+Go: `go version`
+
+Starport: `starport version`
+
+Gaia: `gaiad version --long`
+
+**Tell us about your environment** 
+
+Your system: `uname -a`
 
 **Solution**
-Do you have a solution? See [CONTRIBUTING.md](https://github.com/cosmos/sdk-tutorials/blob/master/CONTRIBUTING.md) and feel free to submit a PR. 
+
+Do you have a solution? Great. Describe it here or even better, see [CONTRIBUTING.md](https://github.com/cosmos/sdk-tutorials/blob/master/CONTRIBUTING.md) and feel free to submit a PR. 

--- a/.github/ISSUE_TEMPLATE/tutorials-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/tutorials-feature-request.md
@@ -11,7 +11,7 @@ Thank you for helping us improve the Cosmos Developer Portal.
 
 Use this form to submit a feature request for a specific tutorial. 
 
-To submit a feature request for the Developers Portal in general, use [Cosmos SDK tutorials feature request](devportal-feature-request.md).
+To submit a feature request for the Developer Portal in general, use [Cosmos SDK tutorials feature request](devportal-feature-request.md).
 
 **Is your feature request related to a problem? Please describe.**
 

--- a/.github/ISSUE_TEMPLATE/tutorials-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/tutorials-feature-request.md
@@ -7,11 +7,20 @@ assignees: ''
 
 ---
 
+Thank you for helping us improve the Cosmos Developers Portal. 
+
+Use this form to submit a feature request for a specific tutorial. 
+
+To submit a feature request for the Developers Portal in general, use [Cosmos SDK tutorials feature request](devportal-feature-request.md).
+
 **Is your feature request related to a problem? Please describe.**
+
 A clear and concise description of what the problem is. Explain your friction point. For example, I'm always frustrated when [...]
 
 **Describe the solution you'd like to see**
+
 A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
+
 A clear and concise description of alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/tutorials-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/tutorials-feature-request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Thank you for helping us improve the Cosmos Developers Portal. 
+Thank you for helping us improve the Cosmos Developer Portal. 
 
 Use this form to submit a feature request for a specific tutorial. 
 

--- a/.github/ISSUE_TEMPLATE/tutorials-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/tutorials-feature-request.md
@@ -7,11 +7,11 @@ assignees: ''
 
 ---
 
-Thank you for helping us improve the Cosmos Developer Portal. 
+Thank you for helping us improve Cosmos SDK Tutorials. 
 
 Use this form to submit a feature request for a specific tutorial. 
 
-To submit a feature request for the Developer Portal in general, use [Cosmos SDK tutorials feature request](devportal-feature-request.md).
+To submit a feature request for the Developer Portal in general, use [Developer Portal feature request](devportal-feature-request.md).
 
 **Is your feature request related to a problem? Please describe.**
 


### PR DESCRIPTION
hi B9Lab friends! 

The existing templates in the repo were created for specific Cosmos SDK tutorials and no longer serve the larger Developers Portal repo.

To help us capture relevant feedback and bug reports for the new (fancy!) Developers Portal, I've created new issue templates for the Developers Portal in general and updated the tutorial-specific templates.

