### PR TITLE
Developers Portal codeowners: assign B9lab team as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
 # Docs 
-*.md @citmc @cmwaters @nooomski @coldice 
+*.md @citmc @cmwaters @nooomski @xavierlepretre @coldice 
 
 # Primary repo maintainers
 * @coldice @gioelebonifetto @8bitpal 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 *.md @citmc @cmwaters @nooomski @xavierlepretre @coldice 
 
 # Primary repo maintainers
-* @coldice @gioelebonifetto @8bitpal 
+* @coldice @xavierlepretre @gioelebonifetto @8bitpal 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+
+# Docs 
+*.md @citmc @cmwaters @nooomski @coldice 
+
+# Primary repo maintainers
+* @coldice @gioelebonifetto @8bitpal 


### PR DESCRIPTION
Now that we have our fabulous new Developers Portal, let's ensure that the PRs are able to be merged.

In past cycles, @toschdev and I relied only on each other to merge PRs, and this bottleneck was ineffective for getting fixes published quickly.

Let's assign the B9lab team as codeowners.

We can use pattern matching for relevant content reviewers. For now, PR reviewers can be selected for each PR if these auto codeowner assignments don't work. it's a start! 

See https://help.github.com/articles/about-codeowners/ for details. 

See IBC CODEOWNERS for a good example of pattern matching by content type

https://github.com/cosmos/ibc-go/blob/main/.github/CODEOWNERS 