### PR TITLE
fix cp command for busybox cp

### DIFF
--- a/assets-optimizer.sh
+++ b/assets-optimizer.sh
@@ -7,6 +7,6 @@ echo "Resize: Started to resize images using sharp"
 sharp resize 988 -i {*,*/*,*/*/*,.*/*}/*.{png,jpg} -o .vuepress/public/resized-images --optimise true --withMetadata false
 echo "Resize: Completed"
 echo "Copy: Adds remaining small images to the same output folder"
-find . \( -name 'node_modules' -o -path './.vuepress/dist' -o -path './.vuepress/theme' -o -path './.vuepress/public/resized-images' -o -path './.vuepress/public/h5p' \) -prune -o \( -name '*.png' -o -name '*.jpg' \) -exec cp -n -v {} .vuepress/public/resized-images \;
+find . \( -name 'node_modules' -o -path './.vuepress/dist' -o -path './.vuepress/theme' -o -path './.vuepress/public/resized-images' -o -path './.vuepress/public/h5p' \) -prune -o \( -name '*.png' -o -name '*.jpg' \) -exec cp -vu {} .vuepress/public/resized-images \;
 echo "Copy: Completed"
 echo "Assets optimization completed"


### PR DESCRIPTION
Fixes the asset optimization script `cp` call (busybox compatibility), to fix the build error [https://github.com/cosmos/sdk-tutorials/runs/4414182874?check_suite_focus=true#step:4:147](https://github.com/cosmos/sdk-tutorials/runs/4414182874?check_suite_focus=true#step:4:147)