### PR TITLE
docs: small typo/linkfix

### DIFF
--- a/academy/1-what-is-cosmos/cosmos-ecosystem.md
+++ b/academy/1-what-is-cosmos/cosmos-ecosystem.md
@@ -21,7 +21,7 @@ Cosmos is an ever-expanding ecosystem of tokens, wallets, tools, as well as inte
 
 In 2022 almost **$100 billion in digital assets** are under management and secured by Cosmos. Digital assets on Cosmos include fungible and non-fungible tokens (NFT). You can issue in-application tokens to conduct settlements, bespoke issuance, handle inflation/deflation and much more.
 
-Among the fungible tokens secured by Cosmos are the [Binance Coin](https://www.binance.com/en/bnb), [Terra](https://www.terra.money/  and [ATOM](https://cosmos.network/learn/faq/what-is-the-atom). Remember that because the tokens are defined on application-specific blockchains their developers are free from the constraints of a hypothetical general-purpose blockchain.
+Among the fungible tokens secured by Cosmos are the [Binance Coin](https://www.binance.com/en/bnb), [Terra](https://www.terra.money) and [ATOM](https://cosmos.network/learn/faq/what-is-the-atom). Remember that because the tokens are defined on application-specific blockchains their developers are free from the constraints of a hypothetical general-purpose blockchain.
 
 <HighlightBox type="tip">
 

--- a/academy/3-running-a-chain/index.md
+++ b/academy/3-running-a-chain/index.md
@@ -10,7 +10,7 @@ intro:
     title: Running a Chain
     image: /resized-images/cosmos_dev_portal_module-04-lp.png
     description: |
-      Do you want to find out how to interact with Cosmos chains? Let’s take it step-by-step with simppp. <br/><br/>
+      Do you want to find out how to interact with Cosmos chains? Let’s take it step-by-step with simapp. <br/><br/>
       In the end, you will know how to run a node. <br/><br/>
       A cosmos of chains is awaiting!
 ---


### PR DESCRIPTION
Fixes a typo on the running a chain landingpage (academy/3-running-a-chain/index.md)
Fixes a link snytax error on the cosmos eco-system page (academy/1-what-is-cosmos/cosmos-ecosystem.md)