### PR TITLE
fix: fix main menu, re-add whats next section

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -92,7 +92,12 @@ module.exports = {
               title: "My Own Cosmos Chain",
               path: "/academy/4-my-own-chain",
               directory: true,
-            }
+            },
+            {
+              title: "What's Next?",
+              path: "/academy/5-whats-next/",
+              directory: false,
+            },
           ],
         },
         {


### PR DESCRIPTION
We lost the _What's next_ section link in the main menu in the last update - this re-adds it.