### PR TITLE
Fixed typo

### DIFF
--- a/academy/2-main-concepts/transactions.md
+++ b/academy/2-main-concepts/transactions.md
@@ -147,7 +147,7 @@ Want more information on broadcasting with Tendermint RPC? Why not take a closer
 
 ## Next up
 
-In the [next section](./messages.md)), you can learn how transaction messages are generated and handled in the Cosmos SDK.
+In the [next section](./messages.md), you can learn how transaction messages are generated and handled in the Cosmos SDK.
 
 <ExpansionPanel title="Show me some code for my checkers blockchain">
 


### PR DESCRIPTION
This PR removed duplicated `)` in `academy/2-main-concepts/transactions.md`

### Change scope

The changes in this Pull Request include (please tick all that apply):

- [x] Small language/grammar fixes
- [ ] Small content fixes 
- [ ] Addition of new content
- [ ] Sample code/command updates
- [ ] Platform fixes
- [ ] Other
