### PR TITLE
Fix typo: Multistore

### DIFF
--- a/academy/2-main-concepts/base-app.md
+++ b/academy/2-main-concepts/base-app.md
@@ -15,7 +15,7 @@ Before looking at `BaseApp`, make sure to read the previous sections:
 * [Transactions](./transactions.md)
 * [Messages](./messages.md)
 * [Modules](./modules.md)
-* [Multistora and Keepers](./multistore-keepers.md)
+* [Multistore and Keepers](./multistore-keepers.md)
 
 Discover how to define an application state machine and service router, how to create custom transaction processing, and how to create periodic processes that execute at the beginning or end of each block.
 


### PR DESCRIPTION
This PR fixes a small typo in the Base App section: "Multistore" instead of "Multistora"

### Change scope

The changes in this Pull Request include (please tick all that apply):

- [x] Small language/grammar fixes
- [ ] Small content fixes 
- [ ] Addition of new content
- [ ] Sample code/command updates
- [ ] Platform fixes
- [ ] Other
