### PR TITLE
fix: restore tutorials category in main nav

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -459,6 +459,26 @@ module.exports = {
             },
           ],
         },
+        {
+          title: "Tutorials",
+          children: [
+            {
+              title: "Understanding IBC denoms",
+              path: "/tutorials/understanding-ibc-denoms/",
+              directory: false,
+            },
+            {
+              title: "Understanding the Authz Module",
+              path: "/authz-module/",
+              directory: false,
+            },
+            {
+              title: "Understanding the Feegrant Module",
+              path: "/tutorials/understanding-feegrant/",
+              directory: false,
+            }
+          ],
+        },
       ],
     },
     gutter: {


### PR DESCRIPTION
This re-adds the tutorials category to the main nav