### PR TITLE
Update Ethereum gas price unit

### DIFF
--- a/academy/0.0-B9lab-Blockchains/3_managed.md
+++ b/academy/0.0-B9lab-Blockchains/3_managed.md
@@ -56,7 +56,7 @@ The most important difference compared to Bitcoin is the implementation of distr
 
 The code execution platform is [Turing-complete](https://en.wikipedia.org/wiki/Turing_completeness). As part of Turing-completeness, frameworks must overcome the [halting problem](https://www.scientificamerican.com/article/why-is-turings-halting-pr/), which is especially difficult in distributed, hierarchy-free computing platforms. 
 
-In simple terms, the halting problem describes a scenario in which a program loops forever. Ethereum's solution is to introduce **Gas** as a fee for each computational step. Every block has a maximum Gas limit which limits the number of computational steps that can be executed per block - just like a combustion engine, if the Gas runs out then the program stops. Gas only exists during the execution of a transaction and the user is free to specify any **Gas price** in terms of **Ether**, a value which Ethereum requires to convert **Ether to Gas**.
+In simple terms, the halting problem describes a scenario in which a program loops forever. Ethereum's solution is to introduce **Gas** as a fee for each computational step. Every block has a maximum Gas limit which limits the number of computational steps that can be executed per block - just like a combustion engine, if the Gas runs out then the program stops. Gas only exists during the execution of a transaction and the user is free to specify any **Gas price** in terms of **Gwei**, a value which Ethereum requires to convert **Ether to Gas**.
 
 <HighlightBox type="info">
 


### PR DESCRIPTION
Documentation content update for the Public and Managed Blockchains page in the Week 0 section of the Interchain Developer Academy.

This PR updates the mentioned unit of Ethereum gas prices.

Reading through the documentation I noticed it said "any **Gas price** in terms of **Ether**, a value which Ethereum requires to convert **Ether to Gas**". Using Ether twice in this way sounded a little weird to me and normally Ethereum gas prices are specified in Gwei, so I thought this may have just been a typo. Although since Gwei is just Ether with a shifted decimal place, I could see an argument to keep it how it was as maybe the original meant to keep it simple for new users.

### Change scope

The changes in this Pull Request include (please tick all that apply):

- [x] Small language/grammar fixes
- [ ] Small content fixes 
- [ ] Addition of new content
- [ ] Sample code/command updates
- [ ] Platform fixes
- [ ] Other
