### PR TITLE
fix module overview numbering

### DIFF
--- a/academy/4-ibc/index.md
+++ b/academy/4-ibc/index.md
@@ -2,7 +2,7 @@
 parent:
   title: The Inter-Blockchain Communication Protocol
   description: Connect chains
-  number: 5
+  number: 4
 tag: deep-dive
 order: 0
 title: Chapter Overview - The Inter-Blockchain Communication Protocol

--- a/academy/5-cosmjs/index.md
+++ b/academy/5-cosmjs/index.md
@@ -2,7 +2,7 @@
 parent:
   title: CosmJS
   description: The TypeScript library for the Cosmos SDK
-  number: 6
+  number: 5
 tag: deep-dive
 order: 0
 title: Chapter Overview - CosmJS

--- a/academy/6-whats-next/index.md
+++ b/academy/6-whats-next/index.md
@@ -2,7 +2,7 @@
 parent:
   title: What's Next?
   description: Continue your Cosmos journey
-  number: 7
+  number: 6
 tag: fast-track
 ---
 


### PR DESCRIPTION
The module numbering is off by one here from IBC: https://tutorials.cosmos.network/academy/0-welcome/
This PR fixes it.

### Change scope

The changes in this Pull Request include (please tick all that apply):

- [ ] Small language/grammar fixes
- [ ] Small content fixes 
- [ ] Addition of new content
- [ ] Sample code/command updates
- [ ] Platform fixes
- [x] Other
