### PR TITLE
fix: fix typo in group tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ tutorials:
   - title: Understanding the Group Module
     level: intermediate
     description: Learn what the Group module does, how to create group, and how to submit group proposals.
-    url: /tutorials/understanding-groups
+    url: /tutorials/understanding-group
   - title: Understanding the Authz Module
     level: intermediate
     description: Learn what the Authz module does, how to create and revoke authorizations, and how to execute authorized transactions.


### PR DESCRIPTION
Fixes the 404 link to the group module tutorial.

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [ ] Small language/grammar fixes
* [x] Small content fixes 
* [ ] Addition of new content
* [ ] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
