### PR TITLE
fix: fix invalid sdk modules links

### DIFF
--- a/academy/2-main-concepts/messages.md
+++ b/academy/2-main-concepts/messages.md
@@ -51,7 +51,7 @@ The confirmed transaction is relayed to the Cosmos SDK application for interpret
 
 Although it is technically feasible to proceed to create a novel `MsgService`, the recommended approach is to define a Protobuf `Msg` service. Each module has exactly one Protobuf `Msg` service defined in `tx.proto` and there is an RPC service method for each message type in the module. The Protobuf message service implicitly defines the interface layer of the state, mutating processes contained within the module.
 
-How does all of this translate into code? Here is an example `MsgService` from the [`bank` module](https://docs.cosmos.network/main/modules/bank/):
+How does all of this translate into code? Here is an example `MsgService` from the [`bank` module](https://docs.cosmos.network/v0.46/modules/bank/):
 
 ```protobuf
 // Msg defines the bank Msg service.
@@ -305,7 +305,7 @@ What would happen if a player stops taking turns? To ensure functionality for yo
 * Having a timeout after which the game is forfeited. You could also automatically charge the forgetful player, if and when you implement a wager system.
 * Keeping an index of games that could be forfeited. If both timeouts are the same, you can keep a single FIFO list of games, so you can clear them from the top of the list as necessary.
 
-In general terms, you could add `timeout: Timestamp` to your `StoredGame` and update it every time something changes in the game. You can decide on a maximum delay, for example *one day*.
+In general terms, you could add `timeout: Timestamp` to your `StoredGame` and update it every time something changes in the game. You can decide on a maximum delay, for example _one day_.
 
 <HighlightBox type="info">
 

--- a/academy/2-main-concepts/migrations.md
+++ b/academy/2-main-concepts/migrations.md
@@ -114,7 +114,7 @@ Application developers build implementations of those components that are tailor
 
 <HighlightBox type="docs">
 
-For a more detailed explanation of the upgrade process, see the [Cosmos SDK documentation](https://docs.cosmos.network/main/modules/upgrade).
+For a more detailed explanation of the upgrade process, see the [Cosmos SDK documentation](https://docs.cosmos.network/v0.46/modules/upgrade).
 
 </HighlightBox>
 

--- a/academy/xl-run-prod/3-genesis.md
+++ b/academy/xl-run-prod/3-genesis.md
@@ -77,7 +77,7 @@ This credits her with 5 STONE and 2 FLINT. It has also given her an `account_num
 
 You can do the same for all your genesis accounts, which includes your validators.
 
-Advanced topics include [vesting](https://docs.cosmos.network/main/modules/auth/05_vesting.html) on these genesis accounts. For information on how to configure them, do:
+Advanced topics include [vesting](https://docs.cosmos.network/v0.46/modules/auth/05_vesting.html) on these genesis accounts. For information on how to configure them, do:
 
 ```sh
 $ ./myprojectd add-genesis-account --help

--- a/tutorials/understanding-group/index.md
+++ b/tutorials/understanding-group/index.md
@@ -20,8 +20,8 @@ When the group module is enabled in a chain (say the Cosmos Hub), users can crea
 Before starting, review some terminology:
 
 * **Group Admin:** the account that creates the group is the group administrator. The group administrator is the account that can add, remove, or change the group members, but does not need to be a member of the group itself. Choose it wisely.
-* **[Group policy](https://docs.cosmos.network/main/modules/group/01_concepts.html#group-policy):** a group policy is an account associated with a group and a decision policy. In order to perform actions on this account, a proposal must be approved by a majority of the group members or as defined in the decision policy. For the avoidance of doubt, note that a group can have multiple group policies.
-* **[Decision policy](https://docs.cosmos.network/main/modules/group/01_concepts.html#decision-policy):** a policy that defines how the group members can vote on a proposal and how the vote outcome is calculated. A decision policy is associated with a group policy. This means that a group can have different decision policies for each of its different group policies.
+* **[Group policy](https://docs.cosmos.network/v0.46/modules/group/01_concepts.html#group-policy):** a group policy is an account associated with a group and a decision policy. In order to perform actions on this account, a proposal must be approved by a majority of the group members or as defined in the decision policy. For the avoidance of doubt, note that a group can have multiple group policies.
+* **[Decision policy](https://docs.cosmos.network/v0.46/modules/group/01_concepts.html#decision-policy):** a policy that defines how the group members can vote on a proposal and how the vote outcome is calculated. A decision policy is associated with a group policy. This means that a group can have different decision policies for each of its different group policies.
 * **Proposal:** a group proposal works the same way as a governance proposal. Group members can submit proposals to the group and vote on proposals with a _Yes_, _No_, _No with Veto_, and _Abstain_.
 
 In this tutorial, you will learn how to create a group, manage its members, submit a group proposal, and vote on it. After that, you will be able to create your own on-chain DAO for your own use case.
@@ -428,4 +428,4 @@ $ simd tx group --help
 $ simd query group --help
 ```
 
-To learn more about the group module specs, check out the [group](https://docs.cosmos.network/main/modules/group) module developer documentation.
+To learn more about the group module specs, check out the [group](https://docs.cosmos.network/v0.46/modules/group) module developer documentation.


### PR DESCRIPTION
We've migrated some links on our devel version. We should pin the v0.46 version to keep the same links (as devel is subject to change).