### PR TITLE
fix: fix version typo in gov tutorial

### DIFF
--- a/tutorials/understanding-gov/index.md
+++ b/tutorials/understanding-gov/index.md
@@ -73,7 +73,7 @@ Make sure the installation was successful:
 $ simd version
 ```
 
-The returned version number should be greater than or equal to `0.46.2`.
+The returned version number should be equal to `0.46.2`.
 
 ## Configuration
 

--- a/tutorials/understanding-gov/index.md
+++ b/tutorials/understanding-gov/index.md
@@ -50,10 +50,10 @@ In the Cosmos SDK [v0.46.0 release](https://docs.cosmos.network/v0.46/modules/go
 To install `simd`, first clone the Cosmos SDK GitHub repository and checkout the right version:
 
 ```sh
-$ git clone https://github.com/cosmos/cosmos-sdk --depth=1 --branch v0.46.3
+$ git clone https://github.com/cosmos/cosmos-sdk --depth=1 --branch v0.46.2
 ```
 
-You are installing `v0.46.3` because this version added the command `draft-proposal`. You will learn later what it does.
+You are installing `v0.46.2` because this version added the command `draft-proposal`. You will learn later what it does.
 
 Go to the cloned directory:
 
@@ -73,7 +73,7 @@ Make sure the installation was successful:
 $ simd version
 ```
 
-The returned version number should be greater than or equal to `0.46.3`.
+The returned version number should be greater than or equal to `0.46.2`.
 
 ## Configuration
 


### PR DESCRIPTION
Turns out we released the command in `v0.46.2`: https://github.com/cosmos/cosmos-sdk/blob/release/v0.46.x/CHANGELOG.md#v0462---2022-10-03. This updates the tutorial.

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [ ] Small language/grammar fixes
* [x] Small content fixes 
* [ ] Addition of new content
* [ ] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
