### PR TITLE
Split long game wager section into 2.

### DIFF
--- a/.vuepress/redirects
+++ b/.vuepress/redirects
@@ -56,7 +56,7 @@
 /academy/3-my-own-chain/game-deadline.html /hands-on-exercise/2-ignite-cli-adv/2-game-deadline.html
 /academy/3-my-own-chain/game-winner.html /hands-on-exercise/2-ignite-cli-adv/3-game-winner.html
 /academy/3-my-own-chain/game-forfeit.html /hands-on-exercise/2-ignite-cli-adv/4-game-forfeit.html
-/academy/3-my-own-chain/game-wager.html /hands-on-exercise/2-ignite-cli-adv/5-game-wager
+/academy/3-my-own-chain/game-wager.html /hands-on-exercise/2-ignite-cli-adv/4-game-wager
 /academy/3-my-own-chain/gas-meter.html /hands-on-exercise/2-ignite-cli-adv/6-gas-meter.html
 /academy/3-my-own-chain/can-play.html /hands-on-exercise/2-ignite-cli-adv/7-can-play.html
 /academy/3-my-own-chain/wager-denom.html /hands-on-exercise/2-ignite-cli-adv/8-wager-denom.html
@@ -67,3 +67,4 @@
 /academy/6-whats-next/ /academy/whats-next/
 /hands-on-exercise/5-run-in-prod/ /tutorials/8-path-to-prod/
 /hands-on-exercise/2-ignite-cli-adv/9-migration.html /hands-on-exercise/4-run-in-prod/2-migration.html
+/hands-on-exercise/2-ignite-cli-adv/5-game-wager.html /hands-on-exercise/2-ignite-cli-adv/4-game-wager.html

--- a/README.md
+++ b/README.md
@@ -314,8 +314,10 @@ customModules:
             path: /hands-on-exercise/2-ignite-cli-adv/3-game-winner.html
           - title: Including auto-expiring of games
             path: /hands-on-exercise/2-ignite-cli-adv/4-game-forfeit.html
-          - title: Allowing wagers
-            path: /hands-on-exercise/2-ignite-cli-adv/5-game-wager.html
+          - title: Including a wager
+            path: /hands-on-exercise/2-ignite-cli-adv/4-game-wager.html
+          - title: Handling wager payments
+            path: /hands-on-exercise/2-ignite-cli-adv/5-payment-winning.html
           - title: Incentiving players
             path: /hands-on-exercise/2-ignite-cli-adv/6-gas-meter.html
           - title: Help find correct moves

--- a/hands-on-exercise/1-ignite-cli/3-stored-game.md
+++ b/hands-on-exercise/1-ignite-cli/3-stored-game.md
@@ -745,7 +745,7 @@ You can do the same for [`Red`](https://github.com/cosmos/b9-checkers-academy-dr
 
 Test that [you can parse a game](https://github.com/cosmos/b9-checkers-academy-draft/blob/full-game-object/x/checkers/types/full_game_test.go#L67-L71), even [if it has been tampered with](https://github.com/cosmos/b9-checkers-academy-draft/blob/full-game-object/x/checkers/types/full_game_test.go#L73-L79), except [if the tamper is wrong](https://github.com/cosmos/b9-checkers-academy-draft/blob/full-game-object/x/checkers/types/full_game_test.go#L81-L88) or [if the turn is wrongly saved](https://github.com/cosmos/b9-checkers-academy-draft/blob/full-game-object/x/checkers/types/full_game_test.go#L90-L97).
 
-Interested in integration tests? Skip ahead to the [section](/hands-on-exercise/2-ignite-cli-adv/5-game-wager.md) where you learn about them.
+Interested in integration tests? Skip ahead to the [section](/hands-on-exercise/2-ignite-cli-adv/5-payment-winning.md) where you learn about them.
 
 ## Interact via the CLI
 

--- a/hands-on-exercise/1-ignite-cli/5-create-handling.md
+++ b/hands-on-exercise/1-ignite-cli/5-create-handling.md
@@ -516,6 +516,6 @@ You will learn how to modify this handling in later sections by:
 * Adding [an event](./7-events.md).
 * Consuming [some gas](/hands-on-exercise/2-ignite-cli-adv/6-gas-meter.md).
 * Facilitating the eventual [deadline enforcement](/hands-on-exercise/2-ignite-cli-adv/4-game-forfeit.md).
-* Adding [_money_](/hands-on-exercise/2-ignite-cli-adv/5-game-wager.md) handling, including [foreign tokens](/hands-on-exercise/2-ignite-cli-adv/8-wager-denom.md).
+* Adding [_money_](/hands-on-exercise/2-ignite-cli-adv/4-game-wager.md) handling, including [foreign tokens](/hands-on-exercise/2-ignite-cli-adv/8-wager-denom.md).
 
 <!--Now that a game is created, it is time to play it by adding moves. That is the subject of the [next section](./6-play-game.md).-->

--- a/hands-on-exercise/1-ignite-cli/8-reject-game.md
+++ b/hands-on-exercise/1-ignite-cli/8-reject-game.md
@@ -690,6 +690,6 @@ Next week's sections cover forfeits and how games end. In the next section, you 
 
 <HighlightBox type="tip">
 
-If you want to enable token wagers in your games instead, skip ahead to [wagers](/hands-on-exercise/2-ignite-cli-adv/5-game-wager.md).
+If you want to enable token wagers in your games instead, skip ahead to [wagers](/hands-on-exercise/2-ignite-cli-adv/4-game-wager.md).
 
 </HighlightBox>-->

--- a/hands-on-exercise/2-ignite-cli-adv/4-game-forfeit.md
+++ b/hands-on-exercise/2-ignite-cli-adv/4-game-forfeit.md
@@ -698,4 +698,4 @@ To summarize, this section has explored:
 
 <!--## Next up
 
-With no games staying in limbo forever, the project is now ready to use token wagers. These are introduced in the [next section](./5-game-wager.md).-->
+With no games staying in limbo forever, the project is now ready to use token wagers. These are introduced in the [next section](./4-game-wager.md).-->

--- a/hands-on-exercise/2-ignite-cli-adv/4-game-wager.md
+++ b/hands-on-exercise/2-ignite-cli-adv/4-game-wager.md
@@ -1,0 +1,368 @@
+---
+title: "Let Players Set a Wager"
+order: 5
+description: Token - players set a wager
+tags: 
+  - guided-coding
+  - cosmos-sdk
+---
+
+# Let Players Set a Wager
+
+<HighlightBox type="prerequisite">
+
+Make sure you have everything you need before proceeding:
+
+* You understand the concepts of [transactions](/academy/2-cosmos-concepts/3-transactions.md), [messages](/academy/2-cosmos-concepts/4-messages.md), and [Protobuf](/academy/2-cosmos-concepts/6-protobuf.md).
+* Go is installed.
+* You have the checkers blockchain codebase up to game expiry handling. If not, follow the [previous steps](./4-game-forfeit.md) or check out [the relevant version](https://github.com/cosmos/b9-checkers-academy-draft/tree/forfeit-game).
+
+</HighlightBox>
+
+<HighlightBox type="learning">
+
+In this section, you will:
+
+* Add wager information (only).
+* Update unit tests.
+
+</HighlightBox>
+
+With the introduction of game expiry in the [previous section](./4-game-forfeit.md) and other features, you have now addressed the cases when two players start a game and finish it, or let it expire.
+
+In this section, you will go one step closer to adding an extra layer to a game, with wagers or stakes. Your application already includes all the necessary modules.
+
+Players choose to wager _money_ or not, and the winner gets both wagers. The forfeiter loses their wager. To reduce complexity, start by letting players wager in the staking token of your application.
+
+Now that no games can be left stranded, it is possible for players to safely wager on their games. How could this be implemented?
+
+## Some initial thoughts
+
+When thinking about implementing a wager on games, ask:
+
+* What form will a wager take?
+* Who decides on the amount of wagers?
+* Where is a wager recorded?
+* At what junctures do you need to handle payments, refunds, and wins?
+
+This is a lot to go through. Therefore, the work is divided into two sections. In this section you only add new information, while the [next section](./5-payment-winning.md) is where the tokens are actually handled.
+
+Some answers:
+
+* Even if only as a start, it makes sense to let the game creator decide on the wager.
+* It seems reasonable to save this information in the game itself so that wagers can be handled at any point in the lifecycle of the game.
+
+## Code needs
+
+When it comes to your code:
+
+* What Ignite CLI commands, if any, will assist you?
+* How do you adjust what Ignite CLI created for you?
+* Where do you make your changes?
+* What event should you emit?
+* How would you unit-test these new elements?
+* How would you use Ignite CLI to locally run a one-node blockchain and interact with it via the CLI to see what you get?
+
+## New information
+
+Add this wager value to the `StoredGame`'s Protobuf definition:
+
+```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-wager/proto/checkers/stored_game.proto#L17]
+message StoredGame {
+    ...
+    uint64 wager = 11;
+}
+```
+
+You can let players choose the wager they want by adding a dedicated field in the message to create a game, in `proto/checkers/tx.proto`:
+
+```protobuf [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-wager/proto/checkers/tx.proto#L20]
+message MsgCreateGame {
+    ...
+    uint64 wager = 4;
+}
+```
+
+Have Ignite CLI and Protobuf recompile these two files:
+
+<CodeGroup>
+
+<CodeGroupItem title="Local" active>
+
+```sh
+$ ignite generate proto-go
+```
+
+</CodeGroupItem>
+
+<CodeGroupItem title="Docker">
+
+```sh
+$ docker run --rm -it \
+    -v $(pwd):/checkers \
+    -w /checkers \
+    checkers_i \
+    ignite generate proto-go
+```
+
+</CodeGroupItem>
+
+</CodeGroup>
+
+Now add a helper function to `StoredGame` using the Cosmos SDK `Coin` in `full_game.go`:
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-wager/x/checkers/types/full_game.go#L68-L70]
+func (storedGame *StoredGame) GetWagerCoin() (wager sdk.Coin) {
+    return sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(int64(storedGame.Wager)))
+}
+```
+
+This encapsulates information about the wager (where `sdk.DefaultBondDenom` is most likely `"stake"`).
+
+## Saving the wager
+
+Time to ensure that the new field is saved in the storage and it is part of the creation event.
+
+1. Define a new event key as a constant:
+
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-wager/x/checkers/types/keys.go#L36]
+    const (
+        GameCreatedEventWager = "wager"
+    )
+    ```
+
+2. Set the actual value in the new `StoredGame` as it is instantiated in the create game handler:
+
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-wager/x/checkers/keeper/msg_server_create_game.go#L33]
+    storedGame := types.StoredGame{
+        ...
+        Wager: msg.Wager,
+    }
+    ```
+
+3. And in the event:
+
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-wager/x/checkers/keeper/msg_server_create_game.go#L52]
+    ctx.EventManager().EmitEvent(
+        sdk.NewEvent(sdk.EventTypeMessage,
+            ...
+            sdk.NewAttribute(types.GameCreatedEventWager, strconv.FormatUint(msg.Wager, 10)),
+        )
+    )
+    ```
+
+4. Modify the constructor among the interface definition of `MsgCreateGame` in `x/checkers/types/message_create_game.go` to avoid surprises:
+
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-wager/x/checkers/types/message_create_game.go#L17]
+    func NewMsgCreateGame(creator string, red string, black string, wager uint64) *MsgCreateGame {
+        return &MsgCreateGame{
+            ...
+            Wager: wager,
+        }
+    }
+    ```
+
+5. Adjust the CLI client accordingly:
+
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-wager/x/checkers/client/cli/tx_create_game.go#L17-L38]
+    func CmdCreateGame() *cobra.Command {
+        cmd := &cobra.Command{
+            Use:   "create-game [black] [red] [wager]",
+            Short: "Broadcast message createGame",
+            Args:  cobra.ExactArgs(3),
+            RunE: func(cmd *cobra.Command, args []string) (err error) {
+                argBlack := args[0]
+                argRed := args[1]
+                argWager, err := strconv.ParseUint(args[2], 10, 64)
+                if err != nil {
+                    return err
+                }
+
+                clientCtx, err := client.GetClientTxContext(cmd)
+                if err != nil {
+                    return err
+                }
+
+                msg := types.NewMsgCreateGame(
+                    clientCtx.GetFromAddress().String(),
+                    argBlack,
+                    argRed,
+                    argWager,
+                )
+                if err := msg.ValidateBasic(); err != nil {
+                    return err
+                }
+                return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+            },
+        }
+
+        flags.AddTxFlagsToCmd(cmd)
+
+        return cmd
+    }
+    ```
+
+That is it. Adding _just a field_ is quick.
+
+## Unit tests
+
+Some of your unit tests no longer pass because of this new field. Ajust accordingly.
+
+1. When creating a game:
+
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-wager/x/checkers/keeper/msg_server_create_game_test.go#L27]
+    createResponse, err := msgServer.CreateGame(context, &types.MsgCreateGame{
+        ...
+        Wager: 45,
+    })
+    ```
+
+2. When checking that it was saved correctly:
+
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-wager/x/checkers/keeper/msg_server_create_game_test.go#L64]
+    require.EqualValues(t, types.StoredGame{
+        ...
+        Wager: 45,
+    }, game1)
+    ```
+
+3. When checking that the event was emitted correctly:
+
+    ```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-wager/x/checkers/keeper/msg_server_create_game_test.go#L114]
+    require.EqualValues(t, sdk.StringEvent{
+        Type: "new-game-created",
+        Attributes: []sdk.Attribute{
+            ...
+            {Key: "wager", Value: "45"},
+        },
+    }, event)
+    ```
+
+Go ahead and make the rest of the changes as necessary.
+
+## Interact via the CLI
+
+With the tests done, see what happens at the command-line. All there is to check at this stage is that the wager field appears where expected.
+
+After restarting Ignite CLI, how much do Alice and Bob have to start with?
+
+<CodeGroup>
+
+<CodeGroupItem title="Local" active>
+
+```sh
+$ checkersd query bank balances $alice
+$ checkersd query bank balances $bob
+```
+
+</CodeGroupItem>
+
+<CodeGroupItem title="Docker">
+
+```sh
+$ docker exec -it checkers \
+    checkersd query bank balances $alice
+$ docker exec -it checkers \
+    checkersd query bank balances $bob
+```
+
+</CodeGroupItem>
+
+</CodeGroup>
+
+This prints:
+
+```txt
+balances:
+- amount: "100000000"
+  denom: stake
+- amount: "20000"
+  denom: token
+  pagination:
+  next_key: null
+  total: "0"
+balances:
+- amount: "100000000"
+  denom: stake
+- amount: "10000"
+  denom: token
+  pagination:
+  next_key: null
+  total: "0"
+```
+
+Create a game with a wager:
+
+<CodeGroup>
+
+<CodeGroupItem title="Local" active>
+
+```sh
+$ checkersd tx checkers create-game $alice $bob 1000000 --from $alice
+```
+
+</CodeGroupItem>
+
+<CodeGroupItem title="Docker">
+
+```sh
+$ docker exec -it checkers \
+    checkersd tx checkers create-game $alice $bob 1000000 --from $alice
+```
+
+</CodeGroupItem>
+
+</CodeGroup>
+
+Which mentions the wager:
+
+```txt
+...
+raw_log: '[{"events":[{"type":"message","attributes":[{"key":"action","value":"create_game"}]},{"type":"new-game-created","attributes":[{"key":"creator","value":"cosmos1yysy889jzf4kgd84mf6649gt6024x6upzs6pde"},{"key":"game-index","value":"1"},{"key":"black","value":"cosmos1yysy889jzf4kgd84mf6649gt6024x6upzs6pde"},{"key":"red","value":"cosmos1ktgz57udyk4sprkpm5m6znuhsm904l0een8k6y"},{"key":"wager","value":"1000000"}]}]}]'
+```
+
+Confirm that the balances of both Alice and Bob are unchanged, as expected.
+
+Was the game stored correctly?
+
+<CodeGroup>
+
+<CodeGroupItem title="Local" active>
+
+```sh
+$ checkersd query checkers show-stored-game 1
+```
+
+</CodeGroupItem>
+
+<CodeGroupItem title="Docker">
+
+```sh
+$ docker exec -it checkers \
+    checkersd query checkers show-stored-game 1
+```
+
+</CodeGroupItem>
+
+</CodeGroup>
+
+This returns:
+
+```txt
+storedGame:
+  ...
+  wager: "1000000"
+```
+
+This confirms what you expected with regards to the command-line interactions.
+
+<HighlightBox type="synopsis">
+
+To summarize, this section has explored:
+
+* How to add the new "wager" value, modify the "create a game" message to allow players to choose the wager they want to make, and add a helper function.
+* How to save the wager and adjust an event, modifying the create game handler.
+* How to minimally adjust unit tests.
+* How to interact via the CLI to check that wager valuess are being recorded.
+
+</HighlightBox>

--- a/hands-on-exercise/2-ignite-cli-adv/4-game-wager.md
+++ b/hands-on-exercise/2-ignite-cli-adv/4-game-wager.md
@@ -1,7 +1,7 @@
 ---
 title: "Let Players Set a Wager"
-order: 5
-description: Token - players set a wager
+order: 6
+description: Token - Players set a wager
 tags: 
   - guided-coding
   - cosmos-sdk
@@ -45,7 +45,7 @@ When thinking about implementing a wager on games, ask:
 * Where is a wager recorded?
 * At what junctures do you need to handle payments, refunds, and wins?
 
-This is a lot to go through. Therefore, the work is divided into two sections. In this section you only add new information, while the [next section](./5-payment-winning.md) is where the tokens are actually handled.
+This is a lot to go through. Therefore, the work is divided into two sections. In this section, you only add new information, while the [next section](./5-payment-winning.md) is where the tokens are actually handled.
 
 Some answers:
 
@@ -242,9 +242,9 @@ Go ahead and make the rest of the changes as necessary.
 
 ## Interact via the CLI
 
-With the tests done, see what happens at the command-line. All there is to check at this stage is that the wager field appears where expected.
+With the tests done, see what happens at the command line. All there is to check at this stage is that the wager field appears where expected.
 
-After restarting Ignite CLI, how much do Alice and Bob have to start with?
+After restarting the Ignite CLI, how much do Alice and Bob have to start with?
 
 <CodeGroup>
 
@@ -363,6 +363,6 @@ To summarize, this section has explored:
 * How to add the new "wager" value, modify the "create a game" message to allow players to choose the wager they want to make, and add a helper function.
 * How to save the wager and adjust an event, modifying the create game handler.
 * How to minimally adjust unit tests.
-* How to interact via the CLI to check that wager valuess are being recorded.
+* How to interact via the CLI to check that wager values are being recorded.
 
 </HighlightBox>

--- a/hands-on-exercise/2-ignite-cli-adv/5-payment-winning.md
+++ b/hands-on-exercise/2-ignite-cli-adv/5-payment-winning.md
@@ -1,7 +1,7 @@
 ---
 title: "Handle Wager Payments"
-order: 6
-description: Token - wagers go around
+order: 7
+description: Token - Wagers go around
 tags:
   - guided-coding
   - cosmos-sdk
@@ -23,14 +23,14 @@ Make sure you have everything you need before proceeding:
 
 In this section, you will:
 
-* Work with the Bank module.
+* Work with the bank module.
 * Handle money.
 * Use mocks.
 * Add integration tests.
 
 </HighlightBox>
 
-In the [previous section](./4-game-wager.md), you introduced the wager. On its own, having a `Wager` field is just a piece of information, it does not transfer tokens just by existing.
+In the [previous section](./4-game-wager.md), you introduced a wager. On its own, having a `Wager` field is just a piece of information, it does not transfer tokens just by existing.
 
 Transferring tokens is what this section is about.
 
@@ -81,7 +81,7 @@ A lot is to be done. In order you will:
 
 ## Declaring expectations
 
-On its own the `Wager` field does not make players pay the wager or receive rewards. You need to add handling actions which ask the `bank` module to perform the required token transfers. For that, your keeper needs to ask for a `bank` instance during setup.
+On its own the `Wager` field does not make players pay the wager or receive rewards. You need to add handling actions that ask the `bank` module to perform the required token transfers. For that, your keeper needs to ask for a `bank` instance during setup.
 
 <HighlightBox type="info">
 
@@ -347,7 +347,7 @@ With the desired steps defined in the wager handling functions, it is time to in
 
 If you try running your existing tests you get a compilation error on the [test keeper builder](https://github.com/cosmos/b9-checkers-academy-draft/blob/payment-winning/testutil/keeper/checkers.go#L44-L49). Passing `nil` would not get you far with the tests and creating a full-fledged bank keeper would be a lot of work and not a unit test. See the integration tests below for that.
 
-Instead, you create mocks and use them in unit tests, not only to get the existing tests to pass, but also to verify that the bank is called as expected.
+Instead, you create mocks and use them in unit tests, not only to get the existing tests to pass but also to verify that the bank is called as expected.
 
 ### Prepare mocks
 
@@ -1408,7 +1408,7 @@ It would be difficult to test by CLI when there is a winner after a full game. T
 To summarize, this section has explored:
 
 * How to work with the Bank module and handle players making wagers on games, now that the application supports live games playing to completion (with the winner claiming both wagers) or expiring through inactivity (with the inactive player forfeiting their wager as if losing), and no possibility of withheld value being stranded in inactive games.
-* How to add handling actions which ask the `bank` module to perform the token transfers required by the wager, and where to invoke them in the message handlers.
+* How to add handling actions that ask the `bank` module to perform the token transfers required by the wager, and where to invoke them in the message handlers.
 * How to create a new wager-handling file with functions to collect a wager, refund a wager, and pay winnings, in which `must` prefixes indicate either a user-side error (leading to a failed transaction) or a failure of the application's escrow account (requiring the whole application be terminated).
 * How to run integration tests, which requires you to first build a proper bank keeper, create new helpers, refactor your existing keeper tests, account for the new events being emitted from the bank, and add extra checks of money handling.
 * How to interact with the CLI to check account balances to test that wagers are being withheld and paid.

--- a/hands-on-exercise/2-ignite-cli-adv/6-gas-meter.md
+++ b/hands-on-exercise/2-ignite-cli-adv/6-gas-meter.md
@@ -15,7 +15,7 @@ Make sure you have everything you need before proceeding:
 
 * You understand the concept of gas.
 * Go is installed.
-* You have the checkers blockchain codebase with the game wager and its handling. If not, follow the [previous steps](./5-game-wager.md) or check out the [relevant version](https://github.com/cosmos/b9-checkers-academy-draft/tree/game-wager).
+* You have the checkers blockchain codebase with the game wager and its handling. If not, follow the [previous steps](./5-payment-winning.md) or check out the [relevant version](https://github.com/cosmos/b9-checkers-academy-draft/tree/payment-winning).
 
 </HighlightBox>
 

--- a/hands-on-exercise/2-ignite-cli-adv/6-gas-meter.md
+++ b/hands-on-exercise/2-ignite-cli-adv/6-gas-meter.md
@@ -1,6 +1,6 @@
 ---
 title: "Incentivize Players"
-order: 7
+order: 8
 description: Gas - reward validators proportional to their effort
 tags: 
   - guided-coding

--- a/hands-on-exercise/2-ignite-cli-adv/7-can-play.md
+++ b/hands-on-exercise/2-ignite-cli-adv/7-can-play.md
@@ -1,6 +1,6 @@
 ---
 title: "Help Find a Correct Move"
-order: 8
+order: 9
 description: Query - help players make good transactions
 tags: 
   - guided-coding

--- a/hands-on-exercise/2-ignite-cli-adv/8-wager-denom.md
+++ b/hands-on-exercise/2-ignite-cli-adv/8-wager-denom.md
@@ -1,6 +1,6 @@
 ---
 title: "Play With Cross-Chain Tokens"
-order: 9
+order: 10
 description: Let players wager any fungible token
 tags: 
   - guided-coding

--- a/hands-on-exercise/2-ignite-cli-adv/8-wager-denom.md
+++ b/hands-on-exercise/2-ignite-cli-adv/8-wager-denom.md
@@ -30,7 +30,7 @@ In this section, you will:
 
 </HighlightBox>
 
-When you [introduced a wager](/hands-on-exercise/2-ignite-cli-adv/5-game-wager.md) you enabled players to play a game and bet on the outcome using the base staking token of your blockchain. What if your players want to play with _other_ currencies? Your blockchain can represent a token from any other connected blockchain by using the Inter-Blockchain Communication Protocol (IBC).
+When you [introduced a wager](/hands-on-exercise/2-ignite-cli-adv/4-game-wager.md) you enabled players to play a game and bet on the outcome using the base staking token of your blockchain. What if your players want to play with _other_ currencies? Your blockchain can represent a token from any other connected blockchain by using the Inter-Blockchain Communication Protocol (IBC).
 
 Thus, you could expand the pool of your potential players by extending the pool of possible wager denominations via the use of IBC. How can you do this?
 

--- a/ida-customizations/.vuepress/config.js
+++ b/ida-customizations/.vuepress/config.js
@@ -378,7 +378,11 @@ module.exports = {
                 },
                 {
                   title: "Let Players Set a Wager",
-                  path: "/hands-on-exercise/2-ignite-cli-adv/5-game-wager.html",
+                  path: "/hands-on-exercise/2-ignite-cli-adv/4-game-wager.html",
+                },
+                {
+                  title: "Handle wager payments",
+                  path: "/hands-on-exercise/2-ignite-cli-adv/5-payment-winning.html",
                 },
                 {
                   title: "Incentivize Players",

--- a/ida-customizations/README.md
+++ b/ida-customizations/README.md
@@ -163,7 +163,9 @@ customModules:
           - title: Allow for auto-expiring games
             path: /hands-on-exercise/2-ignite-cli-adv/4-game-forfeit.html
           - title: Let players set a wager
-            path: /hands-on-exercise/2-ignite-cli-adv/5-game-wager.html
+            path: /hands-on-exercise/2-ignite-cli-adv/4-game-wager.html
+          - title: Handle wager payments
+            path: /hands-on-exercise/2-ignite-cli-adv/5-payment-winning.html
           - title: Incentivize players and manage gas
             path: /hands-on-exercise/2-ignite-cli-adv/6-gas-meter.html
           - title: Help find a correct move


### PR DESCRIPTION
Documentation content update for hands-on-exercise / wagers

This PR splits the long "set a wager" section into 2:

* Set a purely informative wager. This is short.
* Add all the token handling parts. This is the long part, now less long, if still long.

Further notes for reviewers:

The "wrong" naming 4-game-forfeit / 4-game-wager is intentional, same with the `order: 5` in-file:

* They are compiled and presented in the right order (alphabetically I reckon).
* This naming will make sense in the future when 2-game-deadline and 3-game-winner are merged together.

### R1: Internal review (B9lab)

- Technical review
  - [x] requested
  - [ ] completed
- Language review
  - [x] requested
  - [ ] completed

### R2: External review

- Technical review
  - [ ] requested
  - [ ] completed
- Language review
  - [ ] requested
  - [ ] completed

### R3: Internal QA review (B9lab)

- Technical review
  - [ ] requested
  - [ ] completed
- Language review
  - [ ] requested
  - [ ] completed

### R4: Final external QA review

- Technical review
  - [ ] requested
  - [ ] completed
- Language review
  - [ ] requested
  - [ ] completed

### RC: Release Candidate

- [x] Ready to be merged

