### PR TITLE
Fix typo in a comment

### DIFF
--- a/academy/3-ibc/5-token-transfer.md
+++ b/academy/3-ibc/5-token-transfer.md
@@ -116,7 +116,7 @@ After a channel is established, the module can start sending and receiving packe
 So where does the module send a token? Take a look at the [msg_server.go](https://github.com/cosmos/ibc-go/blob/v5.1.0/modules/apps/transfer/keeper/msg_server.go) of the token transfer module:
 
 ```go
-// Transfer defines a rpc handler method for MsgTransfer.
+// Transfer defines an rpc handler method for MsgTransfer.
 func (k Keeper) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.MsgTransferResponse, error) {
     ...
 


### PR DESCRIPTION
Documentation content update for [Module 3-ibc, Section 5-token-transfer]

This PR fixes a typo in a comment based on this [update](https://github.com/cosmos/ibc-go/pull/2938/files)

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [ ] Small language/grammar fixes
* [ ] Small content fixes 
* [ ] Addition of new content
* [x] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
