### PR TITLE
Add a Docker checkers standalone

### DIFF
--- a/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md
+++ b/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md
@@ -515,7 +515,7 @@ RPC_URL="http://localhost:26657"
 RPC_URL="http://checkers:26657"
 ```
 
-As you will run the checkers chain in a container named `checkers`.
+This will run the checkers chain in a container named `checkers`.
 
 </CodeGroupItem>
 
@@ -678,7 +678,7 @@ If you are curious about how this `Dockerfile-standalone` was created, head to t
 
 ### Launch the tests
 
-Launch your checkers chain. You can choose your preferred method as long as it can be accessed at the `RPC_URL` you defined earlier. For the purposes of this exercise, you have the choice between three methods:
+Launch your checkers chain. You can choose your preferred method, as long as it can be accessed at the `RPC_URL` you defined earlier. For the purposes of this exercise, you have the choice between three methods:
 
 <CodeGroup>
 
@@ -699,7 +699,7 @@ If your `checkers-net` network already exists, the first command fails with:
 Error response from daemon: network with name checkers-net already exists
 ```
 
-But that is ok.
+But that is okay.
 
 </CodeGroupItem>
 
@@ -731,7 +731,7 @@ If your `checkers-net` network already exists, the first command fails with:
 Error response from daemon: network with name checkers-net already exists
 ```
 
-But that is ok.
+But that is okay.
 
 </CodeGroupItem>
 
@@ -739,12 +739,12 @@ But that is ok.
 
 ---
 
-When using Docker note:
+When using Docker, note:
 
-* `--name checkers` that matches the name you wrote in `RPC_URL`.
+* `--name checkers` matches the name you wrote in `RPC_URL`.
 * `--network checkers-net`, which is reused shortly if you also run your `npm` tests in Docker. See the paragraph on Docker network, later in this section.
 
-Now if you run the tests in another shell:
+Now, if you run the tests in another shell:
 
 <CodeGroup>
 
@@ -767,7 +767,7 @@ $ docker run --rm \
     npm test
 ```
 
-It starts the container on the same network as the blockchain container.
+This starts the container on the same network as the blockchain container.
 
 </CodeGroupItem>
 
@@ -795,9 +795,9 @@ The only combination of running chain / running tests that will not work is if y
 
 You may not have used Docker up to this point. The following paragraphs acquaint you with a Docker _user-defined bridged network_.
 
-If you plan on using Docker Compose at a later stage, having a first taste of such networks is beneficial. Docker Compose can be used to orchestrate and launch separate containers in order to mimic a production setup. And in fact, in the [production section](../4-run-in-prod/1-run-prod-docker.md) of this hands-on exercise, you do just that. If you think this could eventually be useful, you should go through this section. You may want to redo this section with [Docker](https://docs.docker.com/get-docker/).
+If you plan on using Docker Compose at a later stage, having a first taste of such networks is beneficial. Docker Compose can be used to orchestrate and launch separate containers in order to mimic a production setup. In fact, in the [production section](../4-run-in-prod/1-run-prod-docker.md) of this hands-on exercise you do exactly that. If you think this could eventually be useful, you should go through this section. You may want to redo this section with [Docker](https://docs.docker.com/get-docker/).
 
-When you ran the command:
+Earlier you ran the command:
 
 ```sh
 $ docker run --rm -it \
@@ -808,7 +808,7 @@ $ docker run --rm -it \
     checkersd_i:standalone start
 ```
 
-The following happened:
+This produced the following results:
 
 1. A Docker network was created with the name `checkers-net`. If another container is started in this network, all ports are mutually accessible.
 2. Your container started in it with the resolvable name of `checkers`.
@@ -843,9 +843,9 @@ Then, for tests:
 
     </HighlightBox>
 
-Docker networks are used further in the next section.
+Docker networks are explored further in the next section.
 
-When you are done, if you started the chain in Docker, you can stop the containers with:
+When you are done, if you started the chain in Docker you can stop the containers with:
 
 ```sh
 $ docker stop checkers
@@ -858,7 +858,7 @@ To summarize, this section has explored:
 
 * The need to prepare the elements that will eventually allow you to create a GUI and/or server-side scripts for your checkers application.
 * How to create the necessary Protobuf objects and clients in TypeScript, the extensions that facilitate the use of these clients, so that CosmJS will understand and be able to interact with your checkers module.
-* How to use Docker to define a network to launch separate containers that can communicate for the purpose of integration testing.
+* How to use Docker to define a network to launch separate containers that can communicate, for the purpose of integration testing.
 
 </HighlightBox>
 

--- a/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md
+++ b/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md
@@ -497,13 +497,33 @@ $ docker run --rm \
 
 </CodeGroup>
 
-Describe how to connect to the running blockchain in a `.env` file in your project root:
+Describe how to connect to the running blockchain in a `.env` file in your project root. This depends on where you will run the tests, not on where you run the blockchain:
+
+<CodeGroup>
+
+<CodeGroupItem title="Local">
 
 ```ini [https://github.com/cosmos/academy-checkers-ui/blob/stargate/.env#L1]
 RPC_URL="http://localhost:26657"
 ```
 
-Alternatively, use whichever address connects to the RPC port of the checkers blockchain. If your chain runs in a Docker container, you may need to pass your host's IP address.
+</CodeGroupItem>
+
+<CodeGroupItem title="Docker">
+
+```ini [https://github.com/cosmos/academy-checkers-ui/blob/stargate/.env#L1]
+RPC_URL="http://checkers:26657"
+```
+
+As you will run the checkers chain in a container named `checkers`.
+
+</CodeGroupItem>
+
+</CodeGroup>
+
+---
+
+Alternatively, use whichever address connects to the RPC port of the checkers blockchain.
 
 This information will be picked up by the `dotenv` package. Now let TypeScript know about this in an `environment.d.ts` file:
 
@@ -548,7 +568,7 @@ Add the line that describes how the tests are run:
 
 ### First tests
 
-Because the intention is to run these tests against a running chain they cannot expect too much, such as how many games have been created so far. Still, it is possible to at least test that the connection is made and queries pass through.
+Because the intention is to run these tests against a running chain, possibly a fresh one, they cannot expect too much, such as how many games have been created so far. Still, it is possible to at least test that the connection is made and queries pass through.
 
 Create `test/integration/system-info.ts`:
 
@@ -627,15 +647,54 @@ Note the forced import of `import _ from "../../environment"`, to actively infor
 
 </HighlightBox>
 
+### Prepare your checkers chain
+
+There is more than one way to run a checkers blockchain. For instance:
+
+* If you came here after going through the rest of the hands-on exercise, you know how to launch a running chain with Ignite.
+* If you arrived here and are only focussed on learning CosmJS, it is possible to abstract away niceties of the running chain in a minimal package. For this, you need Docker and to create an image:
+
+   1. Get the `Dockerfile`:
+
+       ```sh
+       $ curl -O https://github.com/cosmos/b9-checkers-academy-draft/blob/run-prod/Dockerfile-standalone
+       ```
+
+   2. Build the image:
+
+       ```sh
+       $ docker build . \
+           -f Dockerfile-standalone \
+           -t checkersd_i:standalone
+       ```
+
+If you have another preferred method, make sure to adjust your above `RPC_URL` accordingly.
+
+<HighlightBox type="tip">
+
+If you are curious about how this `Dockerfile-standalone` was created, head to the [run in production](../4-run-in-prod/1-run-prod-docker.md) section.
+
+</HighlightBox>
+
 ### Launch the tests
 
-Launch your checkers chain, for instance from the checkers folder with:
-
-<!-- TODO create a Docker container that contains everything for a pure CosmJS dev to follow along -->
+Launch your checkers chain. You can choose your preferred method as long as it can be accessed at the `RPC_URL` you defined earlier. For the purposes of this exercise, you have the choice between three methods:
 
 <CodeGroup>
 
-<CodeGroupItem title="Local" active>
+<CodeGroupItem title="Docker standalone" active>
+
+```sh
+$ docker run --rm -it \
+    -p 26657:26657 \
+    --name checkers \
+    --network checkers-net \
+    checkersd_i:standalone start
+```
+
+</CodeGroupItem>
+
+<CodeGroupItem title="Local Ignite">
 
 ```sh
 $ ignite chain serve
@@ -643,16 +702,15 @@ $ ignite chain serve
 
 </CodeGroupItem>
 
-<CodeGroupItem title="Docker">
+<CodeGroupItem title="Docker Ignite">
 
 ```sh
 $ docker run --rm -it \
     -v $(pwd):/checkers \
     -w /checkers \
-    -p 1317:1317 \
-    -p 4500:4500 \
-    -p 5000:5000 \
     -p 26657:26657 \
+    --name checkers \
+    --network checkers-net \
     checkers_i \
     ignite chain serve
 ```
@@ -661,7 +719,12 @@ $ docker run --rm -it \
 
 </CodeGroup>
 
-Now if you run the tests:
+When using Docker note:
+
+* `--name checkers` that matches the name you wrote in `RPC_URL`.
+* `--network checkers-net`, which is reused shortly if you also run your `npm` tests in Docker. See the paragraph on Docker network, later in this section.
+
+Now if you run the tests in another shell:
 
 <CodeGroup>
 
@@ -679,6 +742,7 @@ $ npm test
 $ docker run --rm \
     -v $(pwd):/client \
     -w /client \
+    --network checkers-net \
     node:18.7-slim \
     npm test
 ```
@@ -688,6 +752,8 @@ It starts the container on the same network as the blockchain container.
 </CodeGroupItem>
 
 </CodeGroup>
+
+---
 
 This should return:
 
@@ -703,129 +769,61 @@ SystemInfo
 3 passing (287ms)
 ```
 
-## Within a Docker network
+The only combination of running chain / running tests that will not work is if you run Ignite on your local computer and the tests in a container. For this edge case, you should put your host IP address in `RPC_URL`.
 
-You may not have used Docker up to this point. The following paragraphs acquaint you with a Docker _user-defined bridged network_. If you plan on using Docker Compose at a later stage, having a first taste of such networks is beneficial. Docker Compose can be used to orchestrate and launch separate containers in order to mimic a production setup. If you think this could eventually be useful, you should complete this section.
+## A note on Docker networks
 
-Install [Docker](https://docs.docker.com/get-docker/) and clone the [Checkers repository](https://github.com/cosmos/b9-checkers-academy-draft) at the `cosmjs-elements` branch:
+You may not have used Docker up to this point. The following paragraphs acquaint you with a Docker _user-defined bridged network_.
+
+If you plan on using Docker Compose at a later stage, having a first taste of such networks is beneficial. Docker Compose can be used to orchestrate and launch separate containers in order to mimic a production setup. And in fact, in the [production section](../4-run-in-prod/1-run-prod-docker.md) of this hands-on exercise, you do just that. If you think this could eventually be useful, you should go through this section. You may want to redo this section with [Docker](https://docs.docker.com/get-docker/).
+
+When you ran the command:
 
 ```sh
-$ git clone --branch cosmjs-elements https://github.com/cosmos/b9-checkers-academy-draft.git
+$ docker run --rm -it \
+    -p 26657:26657 \
+    --name checkers \
+    --network checkers-net \
+    --detach \
+    checkersd_i:standalone start
 ```
 
-To run the checkers chain with Ignite CLI you have the choice between two Docker images:
+The following happened:
 
-1. You can use the one published by Ignite themselves, for version `0.22.1`: [`ignitehq/cli:0.22.1`](https://hub.docker.com/layers/ignitehq/cli/0.22.1/images/sha256-8e2f353f943227488f966dd02558b718766a17dd8b611bccd2789facdceef0cf). This may be faster the first time you run it, but can become annoying if you plan on doing it many times as it will download the Go dependencies every time.
-2. You can build it yourself from the checkers [`Dockerfile-ubuntu`](https://github.com/cosmos/b9-checkers-academy-draft/blob/cosmjs-elements/Dockerfile-ubuntu), with the command:
+1. A Docker network was created with the name `checkers-net`. If another container is started in this network, all ports are mutually accessible.
+2. Your container started in it with the resolvable name of `checkers`.
+3. With `-p 26657:26657`, port 26657 was forwarded to your host computer, on top of being already shared on the `checkers-net` network.
+
+Then, for tests:
+
+1. When you ran:
 
     ```sh
-    $ docker build -f Dockerfile-ubuntu . -t checkers_i
+    $ npm test
     ```
 
-    <HighlightBox type="best-practice">
+    Your tests, running on the **host** computer, accessed the checkers chain from the host computer via the forwarded port 26657. Hence `RPC_URL="http://localhost:26657"`.
 
-    This is the preferred method if you plan on using the image many times, as it downloads all Go dependencies once.
+2. When you ran:
+
+    ```sh
+    $ docker run --rm \
+        -v $(pwd):/client \
+        -w /client \
+        --network checkers-net \
+        node:18.7-slim \
+        npm test
+    ```
+
+    Your tests, running in a different container, accessed the checkers chain within the `checkers-net` **Docker network** thanks to the `checkers` name resolution. Hence `RPC_URL="http://checkers:26657"`.
+    
+    <HighlightBox type="note">
+
+    In particular, the `-p 26657:26657` port forwarding was not necessary. You can confirm that by stopping your chain and starting it again, this time without `-p`.
 
     </HighlightBox>
 
-Now that you have decided which Docker image to use, you can run the tests.
-
-Create a Docker user-defined bridge network for checkers:
-
-```sh
-$ docker network create checkers-net
-```
-
-Go to the checkers repository folder. Launch the chain's container in the `checkers-net` network, using the DNS-resolvable name of `chain-serve`:
-
-<CodeGroup>
-
-<CodeGroupItem title="With checkers_i">
-
-```sh
-$ docker run --rm -it \
-    -v $(pwd):/checkers \
-    -w /checkers \
-    --network checkers-net \
-    --name chain-serve \
-    checkers_i \
-    ignite chain serve
-```
-
-</CodeGroupItem>
-
-<CodeGroupItem title="With ignitehq/cli">
-
-```sh
-$ docker run --rm -it \
-    -v $(pwd):/checkers \
-    -w /checkers \
-    --network checkers-net \
-    --name chain-serve \
-    ignitehq/cli:0.22.1 \
-    chain serve
-```
-
-Because `ignite` is already the image's entry point, you only need to pass `chain serve`.
-
-</CodeGroupItem>
-
-</CodeGroup>
-
-<HighlightBox type="note">
-
-This time there is no need to publish ports (`-p`) back to the host. Indeed, the communication for the Node.js tests will take place within the `checkers-net` network.
-
-</HighlightBox>
-
-The chain is now served in a container named `chain-serve`. Update your `client` folder's `.env` with this information:
-
-<CodeGroup>
-
-<CodeGroupItem title="By hand">
-
-```ini [https://github.com/cosmos/academy-checkers-ui/blob/stargate/.env#L1]
-RPC_URL="http://chain-serve:26657"
-```
-
-</CodeGroupItem>
-
-<CodeGroupItem title="Linux sed">
-
-```sh
-$ sed -i -E 's/^RPC_URL=.*$/RPC_URL="http:\/\/chain-serve:26657"/g' .env
-```
-
-</CodeGroupItem>
-
-<CodeGroupItem title="MacOS sed">
-
-```sh
-$ sed -i '' -E 's/^RPC_URL=.*$/RPC_URL="http:\/\/chain-serve:26657"/g' .env
-```
-
-</CodeGroupItem>
-
-</CodeGroup>
-
-Again in your `client` folder, you can now run the tests within the same `checkers-net` network:
-
-```sh
-$ docker run --rm \
-    -v $(pwd):/client \
-    -w /client \
-    --network checkers-net \
-    node:18.7-slim \
-    npm test
-```
-
-And that is it. You defined a network over which the Node.js tests' container could easily access the chain's container.
-
-To clean up after you have stopped the containers, you can safely delete the network:
-
-```sh
-$ docker network rm checkers-net
-```
+Docker networks are used further in the next section.
 
 <HighlightBox type="synopsis">
 
@@ -833,7 +831,7 @@ To summarize, this section has explored:
 
 * The need to prepare the elements that will eventually allow you to create a GUI and/or server-side scripts for your checkers application.
 * How to create the necessary Protobuf objects and clients in TypeScript, the extensions that facilitate the use of these clients, so that CosmJS will understand and be able to interact with your checkers module.
-* How to use Docker to define a network to orchestrate and launch separate containers that can communicate for the purpose of integration testing.
+* How to use Docker to define a network to launch separate containers that can communicate for the purpose of integration testing.
 
 </HighlightBox>
 

--- a/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md
+++ b/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md
@@ -17,7 +17,7 @@ Make sure you have everything you need before proceeding:
 * You understand the concepts of [Protobuf](/academy/2-cosmos-concepts/6-protobuf.md).
 * You have completed the introductory [CosmJS tutorial](/tutorials/7-cosmjs/1-cosmjs-intro.md).
 * Go and npm are installed.
-* You have finished the checkers blockchain exercise. If not, you can follow the tutorial [here](/hands-on-exercise/2-ignite-cli-adv/8-wager-denom.md), or just clone and checkout the [relevant branch](https://github.com/cosmos/b9-checkers-academy-draft/tree/wager-denomination) that contains the final version.
+* You have finished the checkers Go blockchain exercise. If not, you can follow the tutorial [here](/hands-on-exercise/2-ignite-cli-adv/8-wager-denom.md), or just clone and checkout the [relevant branch](https://github.com/cosmos/b9-checkers-academy-draft/tree/wager-denomination) that contains the final version.
 
 </HighlightBox>
 

--- a/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md
+++ b/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md
@@ -657,7 +657,7 @@ There is more than one way to run a checkers blockchain. For instance:
    1. Get the `Dockerfile`:
 
        ```sh
-       $ curl -O https://github.com/cosmos/b9-checkers-academy-draft/blob/run-prod/Dockerfile-standalone
+       $ curl -O https://raw.githubusercontent.com/cosmos/b9-checkers-academy-draft/run-prod/Dockerfile-standalone
        ```
 
    2. Build the image:
@@ -685,12 +685,21 @@ Launch your checkers chain. You can choose your preferred method as long as it c
 <CodeGroupItem title="Docker standalone" active>
 
 ```sh
+$ docker network create checkers-net
 $ docker run --rm -it \
     -p 26657:26657 \
     --name checkers \
     --network checkers-net \
     checkersd_i:standalone start
 ```
+
+If your `checkers-net` network already exists, the first command fails with:
+
+```txt
+Error response from daemon: network with name checkers-net already exists
+```
+
+But that is ok.
 
 </CodeGroupItem>
 
@@ -705,6 +714,7 @@ $ ignite chain serve
 <CodeGroupItem title="Docker Ignite">
 
 ```sh
+$ docker network create checkers-net
 $ docker run --rm -it \
     -v $(pwd):/checkers \
     -w /checkers \
@@ -715,9 +725,19 @@ $ docker run --rm -it \
     ignite chain serve
 ```
 
+If your `checkers-net` network already exists, the first command fails with:
+
+```txt
+Error response from daemon: network with name checkers-net already exists
+```
+
+But that is ok.
+
 </CodeGroupItem>
 
 </CodeGroup>
+
+---
 
 When using Docker note:
 
@@ -824,6 +844,13 @@ Then, for tests:
     </HighlightBox>
 
 Docker networks are used further in the next section.
+
+When you are done, if you started the chain in Docker, you can stop the containers with:
+
+```sh
+$ docker stop checkers
+$ docker network rm checkers-net
+```
 
 <HighlightBox type="synopsis">
 

--- a/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md
+++ b/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md
@@ -652,7 +652,7 @@ Note the forced import of `import _ from "../../environment"`, to actively infor
 There is more than one way to run a checkers blockchain. For instance:
 
 * If you came here after going through the rest of the hands-on exercise, you know how to launch a running chain with Ignite.
-* If you arrived here and are only focussed on learning CosmJS, it is possible to abstract away niceties of the running chain in a minimal package. For this, you need Docker and to create an image:
+* If you arrived here and are only focused on learning CosmJS, it is possible to abstract away niceties of the running chain in a minimal package. For this, you need Docker and to create an image:
 
    1. Get the `Dockerfile`:
 

--- a/hands-on-exercise/3-cosmjs-adv/2-cosmjs-messages.md
+++ b/hands-on-exercise/3-cosmjs-adv/2-cosmjs-messages.md
@@ -175,7 +175,7 @@ You should not consider these two functions as the **only** ones that users of `
 
 ## Integration tests
 
-You can reuse the setup you prepared in the previous section. There is an added difficulty: because you send transactions, your tests need access to keys and tokens. How do you provide them in a testing context?
+You can reuse the setup you prepared in the previous section. However, there is an added difficulty: because you send transactions, your tests need access to keys and tokens. How do you provide them in a testing context?
 
 ### Key preparation
 
@@ -300,7 +300,7 @@ If the running chain allows it, and to make your life easier, you can set the ga
 
 ### Token preparation
 
-Just saving keys on disk does not magically make these keys hold tokens on your test blockchain. You need to fund them at their addresses using the funds of other addresses of your running chain. A faucet, if it is set up is convenient for this step.
+Just saving keys on disk does not magically make these keys hold tokens on your test blockchain. You need to fund them at their addresses, using the funds of other addresses of your running chain. A faucet, if one is set up, is convenient for this step.
 
 1. If you use Ignite, it has created a faucet endpoint for you at port `4500`. The page `http://localhost:4500` explains the API.
 2. If you use the [CosmJS faucet](https://www.npmjs.com/package/@cosmjs/faucet), you can make it serve on port `4500` too.
@@ -350,7 +350,7 @@ Also add the faucet address to `environment.d.ts`:
 ...
 ```
 
-In a new separate file, add:
+In a new, separate file, add:
 
 1. A `http` helper function:
 
@@ -376,7 +376,7 @@ In a new separate file, add:
         })
     ```
 
-2. Two helper functions to easily call [CosmJS'](https://www.npmjs.com/package/@cosmjs/faucet) and [Ignite's](/hands-on-exercise/1-ignite-cli/1-ignitecli.md#your-gui) faucets:
+2. Two helper functions to easily call the faucets of [CosmJS](https://www.npmjs.com/package/@cosmjs/faucet) and [Ignite](/hands-on-exercise/1-ignite-cli/1-ignitecli.md#your-gui):
 
     <CodeGroup>
 
@@ -403,7 +403,7 @@ In a new separate file, add:
 
     </CodeGroupItem>
 
-    <CodeGroupItem title="for Ignite's">
+    <CodeGroupItem title="for Ignite">
 
     ```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/src/util/faucet.ts#L47-L58]
     export const askFaucetIgniteCli = async (
@@ -426,12 +426,12 @@ In a new separate file, add:
 
     <HighlightBox type="note">
 
-    * The CosmJS faucet API does **not** let you specify the desired amount.
-    * The Ignite faucet API lets you specify the desired amount.
+    * The CosmJS faucet API **does not** let you specify the desired amount.
+    * The Ignite faucet API **does** let you specify the desired amount.
 
     </HighlightBox>
 
-3. A function that tries one faucet and if that one fails, tries the other:
+3. A function that tries one faucet, and if that one fails tries the other:
 
     ```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/src/util/faucet.ts#L24-L28]
     export const askFaucet = async (
@@ -441,7 +441,7 @@ In a new separate file, add:
         askFaucetComsJs(address, tokens).catch(() => askFaucetIgniteCli(address, tokens))
     ```
 
-You will find out with practice how many tokens your accounts need for the tests. Start with any value. Ignite's default configuration is to start a chain with two tokens: `stake` and `token`, this is a good default. You use both denoms.
+You will find out with practice how many tokens your accounts need for their tests. Start with any value. Ignite's default configuration is to start a chain with two tokens: `stake` and `token`. This is a good default, as you can use both denoms.
 
 Create another `before` that will credit Alice and Bob from the faucet so that they are rich enough to continue:
 
@@ -488,7 +488,7 @@ Your accounts are now ready to proceed with the tests proper.
 
 There are an extra 40 seconds given for this potentially slower process: `this.timeout(40_000)`.
 
-You may want to adjust this time-out value. Here it is set at 10 seconds multiplied by the maximum number of transactions in the function. Here there are at most 4 transactions when calling the CosmJS faucet. Query calls are typically very fast and therefore need not enter in the time-out calculation.
+You may want to adjust this time-out value. Here it is set at _10 seconds multiplied by the maximum number of transactions in the function_. Here there are at most 4 transactions when calling the CosmJS faucet. Query calls are typically very fast, and therefore need not enter in the time-out calculation.
 
 </HighlightBox>
 
@@ -912,13 +912,13 @@ Sending a single transaction with two moves is cheaper and faster, from the poin
 
 <HighlightBox type="note">
 
-It is not possible for Alice, who is the creator and black player, to send in a single transaction a message for creation and a message to make the first move on it. That's because the index of the game is not known before the transaction has been included in a block, and with that the index computed.
+It is not possible for Alice, who is the creator and black player, to send in a single transaction both a message for creation _and_ a message to make the first move on it. This is because the index of the game is not known before the transaction has been included in a block, and with that the index computed.
 
 </HighlightBox>
 
 <HighlightBox type="warn">
 
-Of course, she could try, but if her move failed because of a wrong game id then the whole transaction would revert, and that would include the game creation being reverted.
+Of course, she could try to do this. However, if her move failed because of a wrong game id, then the whole transaction would revert, and that would include the game creation being reverted.
 <br/><br/>
 Worse, a malicious attacker could **front-run** Alice's transaction with another transaction, creating a game where Alice is also the black player and whose id ends up being the one Alice signed in her first move. In the end she would make the first move on a game she did not really intend to play. This game could even have a wager that is _all_ of Alice's token holdings.
 
@@ -935,7 +935,7 @@ If you launch the tests just like you did in the [previous section](/hands-on-ex
 Adjust what you did. 
 
 * If you came here after going through the rest of the hands-on exercise, you know how to launch a running chain with Ignite, which has a faucet to start with.
-* If you arrived here and are only focussed on learning CosmJS, it is possible to abstract away niceties of both the running chain and a faucet in a minimal package. For this, you need Docker and to create an image:
+* If you arrived here and are only focused on learning CosmJS, it is possible to abstract away niceties of both the running chain and a faucet in a minimal package. For this, you need Docker and to create an image:
 
    1. Get the `Dockerfile`:
 
@@ -970,7 +970,7 @@ If you are curious about how this `Dockerfile-standalone` was created, head to t
 
 ### Launch the tests
 
-Launch your checkers chain and the faucet. You can choose your preferred method as long as they can be accessed at the `RPC_URL` and `FAUCET_URL` you defined earlier. For the purposes of this exercise, you have the choice between three methods:
+Launch your checkers chain and the faucet. You can choose your preferred method, as long as they can be accessed at the `RPC_URL` and `FAUCET_URL` you defined earlier. For the purposes of this exercise, you have the choice between three methods:
 
 <CodeGroup>
 
@@ -1000,14 +1000,14 @@ If your `checkers-net` network already exists, the first command fails with:
 Error response from daemon: network with name checkers-net already exists
 ```
 
-But that is ok.
+But that is okay.
 
 <HighlightBox type="note">
 
 * The names match those given in `RPC_URL` and `FAUCET_URL`.
-* The chain needs about 10 seconds to start listening on port 26657. The faucet does not _retry_ so you have to be sure the chain is started.
-* The faucet container itself takes about 20 seconds to be operational as it creates 4 transactions in 4 blocks.
-* Their are started in `--detach`ed mode, but you are free to start them attached in different shells.
+* The chain needs about 10 seconds to start listening on port 26657. The faucet does not _retry_, so you have to be sure the chain is started.
+* The faucet container itself takes about 20 seconds to be operational, as it creates 4 transactions in 4 blocks.
+* They are started in `--detach`ed mode, but you are free to start them attached in different shells.
 
 </HighlightBox>
 
@@ -1043,7 +1043,7 @@ If your `checkers-net` network already exists, the first command fails with:
 Error response from daemon: network with name checkers-net already exists
 ```
 
-But that is ok.
+But that is okay.
 
 <HighlightBox type="note">
 
@@ -1100,7 +1100,7 @@ Remember that `RPC_URL` and `FAUCET_URL` have to mention `checkers` and `cosmos-
 
 The only combination of running chain / running tests that will not work is if you run Ignite on your local computer and the tests in a container. For this edge case, you should put your host IP address in `RPC_URL` and `FAUCET_URL`.
 
-When you are done, if you started the chain in Docker, you can stop the containers with:
+If you started the chain in Docker, when you are done you can stop the containers with:
 
 ```sh
 $ docker stop cosmos-faucet checkers

--- a/hands-on-exercise/3-cosmjs-adv/2-cosmjs-messages.md
+++ b/hands-on-exercise/3-cosmjs-adv/2-cosmjs-messages.md
@@ -15,7 +15,6 @@ Make sure you have all you need before proceeding:
 
 * You understand the concepts of [CosmJS](/tutorials/7-cosmjs/1-cosmjs-intro.md).
 * You have generated the necessary TypeScript types in [the previous tutorial](./1-cosmjs-objects.md). If not, just clone and checkout the [relevant branch](https://github.com/cosmos/academy-checkers-ui/tree/stargate).
-* You have the finished checkers blockchain exercise. If not, you can follow that tutorial [here](/hands-on-exercise/1-ignite-cli/index.md) or just clone and checkout the [branch](https://github.com/cosmos/b9-checkers-academy-draft/tree/cosmjs-elements) that contains the version relevant to this exercise.
 
 </HighlightBox>
 

--- a/hands-on-exercise/3-cosmjs-adv/2-cosmjs-messages.md
+++ b/hands-on-exercise/3-cosmjs-adv/2-cosmjs-messages.md
@@ -940,7 +940,7 @@ Adjust what you did.
    1. Get the `Dockerfile`:
 
        ```sh
-       $ curl -O https://github.com/cosmos/b9-checkers-academy-draft/blob/run-prod/Dockerfile-standalone
+       $ curl -O https://raw.githubusercontent.com/cosmos/b9-checkers-academy-draft/run-prod/Dockerfile-standalone
        ```
 
    2. Build the checkers image:
@@ -977,6 +977,7 @@ Launch your checkers chain and the faucet. You can choose your preferred method 
 <CodeGroupItem title="Docker standalone" active>
 
 ```sh
+$ docker network create checkers-net
 $ docker run --rm -it \
     -p 26657:26657 \
     --name checkers \
@@ -992,6 +993,14 @@ $ docker run --rm -it \
     cosmos-faucet_i:0.28.11 start http://checkers:26657
 $ sleep 20
 ```
+
+If your `checkers-net` network already exists, the first command fails with:
+
+```txt
+Error response from daemon: network with name checkers-net already exists
+```
+
+But that is ok.
 
 <HighlightBox type="note">
 
@@ -1015,6 +1024,7 @@ $ ignite chain serve
 <CodeGroupItem title="Docker Ignite">
 
 ```sh
+$ docker network create checkers-net
 $ docker run --rm -it \
     -v $(pwd):/checkers \
     -w /checkers \
@@ -1026,6 +1036,14 @@ $ docker run --rm -it \
     checkers_i \
     ignite chain serve
 ```
+
+If your `checkers-net` network already exists, the first command fails with:
+
+```txt
+Error response from daemon: network with name checkers-net already exists
+```
+
+But that is ok.
 
 <HighlightBox type="note">
 
@@ -1086,6 +1104,7 @@ When you are done, if you started the chain in Docker, you can stop the containe
 
 ```sh
 $ docker stop cosmos-faucet checkers
+$ docker network rm checkers-net
 ```
 
 <HighlightBox type="synopsis">

--- a/hands-on-exercise/3-cosmjs-adv/2-cosmjs-messages.md
+++ b/hands-on-exercise/3-cosmjs-adv/2-cosmjs-messages.md
@@ -176,11 +176,11 @@ You should not consider these two functions as the **only** ones that users of `
 
 ## Integration tests
 
-You can reuse the setup you prepared in the previous section. There is an added difficulty: because you send transactions, your tests need access to keys. How do you provide them in a testing context?
+You can reuse the setup you prepared in the previous section. There is an added difficulty: because you send transactions, your tests need access to keys and tokens. How do you provide them in a testing context?
 
 ### Key preparation
 
-You would not treat mainnet keys in this way, but here you save testing keys on disk. Update `.env` with the test mnemonics of your choice:
+You would **not** treat mainnet keys in this way, but here you save testing keys on disk. Update `.env` with the test mnemonics of your choice:
 
 <CodeGroup>
 
@@ -199,7 +199,7 @@ You would not treat mainnet keys in this way, but here you save testing keys on 
 <CodeGroupItem title="Docker">
 
 ```diff-txt [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/.env#L3-L6]
-    RPC_URL="http://chain-serve:26657"
+    RPC_URL="http://checkers:26657"
 +  MNEMONIC_TEST_ALICE="theory arrow blue much illness carpet arena thought clay office path museum idea text foot bacon until tragic inform stairs pitch danger spatial slight"
 +  ADDRESS_TEST_ALICE="cosmos1fx6qlxwteeqxgxwsw83wkf4s9fcnnwk8z86sql"
 +  MNEMONIC_TEST_BOB="apple spoil melody venture speed like dawn cherry insane produce carry robust duck language next electric episode clinic acid sheriff video knee spoil multiply"
@@ -301,9 +301,14 @@ If the running chain allows it, and to make your life easier, you can set the ga
 
 ### Token preparation
 
-Just saving keys on disk does not magically make these keys hold tokens on your test blockchain. You need to fund them at their addresses using the funds of other addresses of your running chain. If you use Ignite, it has created a faucet endpoint for you at port `4500`. The page `http://localhost:4500` explains how to make the calls. Use that.
+Just saving keys on disk does not magically make these keys hold tokens on your test blockchain. You need to fund them at their addresses using the funds of other addresses of your running chain. A faucet, if it is set up is convenient for this step.
 
-Add the faucet address in `.env`:
+1. If you use Ignite, it has created a faucet endpoint for you at port `4500`. The page `http://localhost:4500` explains the API.
+2. If you use the [CosmJS faucet](https://www.npmjs.com/package/@cosmjs/faucet), you can make it serve on port `4500` too.
+ 
+For the purpose of this exercise, you will prepare for both faucets.
+
+Add the faucet(s) address in `.env`:
 
 <CodeGroup>
 
@@ -320,14 +325,14 @@ Add the faucet address in `.env`:
 <CodeGroupItem title="Docker">
 
 ```diff-ini [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/.env#L2]
-    RPC_URL="http://chain-serve:26657"
-+  FAUCET_URL="http://chain-serve:4500"
+    RPC_URL="http://checkers:26657"
++  FAUCET_URL="http://cosmos-faucet:4500"
     ...
 ```
 
 </CodeGroupItem>
 
-</CodeGroupItem>
+The name `cosmos-faucet` will be used when starting the faucet container.
 
 </CodeGroup>
 
@@ -346,44 +351,102 @@ Also add the faucet address to `environment.d.ts`:
 ...
 ```
 
-In a new separate file, add two helper functions to easily call Ignite's [faucet](/hands-on-exercise/1-ignite-cli/1-ignitecli.md#your-gui):
+In a new separate file, add:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/src/util/faucet.ts#L4-L31]
-export const httpRequest = async (
-    url: string | URL,
-    options: RequestOptions,
-    postData: string,
-): Promise<string> =>
-    new Promise((resolve, reject) => {
-        let all = ""
-        const req = http.request(url, options, (response: IncomingMessage) => {
-            response.setEncoding("utf8")
-            response.on("error", reject)
-            response.on("end", () => resolve(all))
-            response.on("data", (chunk) => (all = all + chunk))
+1. A `http` helper function:
+
+    ```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/src/util/faucet.ts#L4-L22]
+    export const httpRequest = async (
+        url: string | URL,
+        options: RequestOptions,
+        postData: string,
+    ): Promise<string> =>
+        new Promise((resolve, reject) => {
+            let all = ""
+            const req = http.request(url, options, (response: IncomingMessage) => {
+                response.setEncoding("utf8")
+                response.on("error", reject)
+                response.on("end", () => {
+                    if (400 <= response.statusCode!) reject(all)
+                    else resolve(all)
+                })
+                response.on("data", (chunk) => (all = all + chunk))
+            })
+            req.write(postData)
+            req.end()
         })
-        req.write(postData)
-        req.end()
-    })
+    ```
 
-export const askFaucet = async (address: string, tokens: { [key: string]: number }): Promise<string> =>
-    httpRequest(
-        process.env.FAUCET_URL,
-        {
-            method: "POST",
-        },
-        JSON.stringify({
-            address: address,
-            coins: Object.entries(tokens).map(([key, value]) => value + key),
-        }),
-    )
-```
+2. Two helper functions to easily call [CosmJS'](https://www.npmjs.com/package/@cosmjs/faucet) and [Ignite's](/hands-on-exercise/1-ignite-cli/1-ignitecli.md#your-gui) faucets:
 
-You will find out with practice how many tokens your accounts need for the tests. Start with any value. Ignite's default configuration is to start a chain with two tokens: `stake` and `token`. You use both.
+    <CodeGroup>
 
-Create another `before` that will credit Alice and Bob from the faucet and confirm that they are rich enough to continue:
+    <CodeGroupItem title="for CosmJS">
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L54-L79]
+    ```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/src/util/faucet.ts#L30-L45]
+    export const askFaucetComsJs = async (
+    address: string,
+    tokens: { [denom: string]: number },
+    ): Promise<string[]> =>
+        Promise.all(
+            Object.keys(tokens).map((denom) =>
+                httpRequest(
+                    `${process.env.FAUCET_URL}/credit`,
+                    {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                    },
+                    JSON.stringify({ address, denom }),
+                ),
+            ),
+        )
+    ```
+
+    </CodeGroupItem>
+
+    <CodeGroupItem title="for Ignite's">
+
+    ```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/src/util/faucet.ts#L47-L58]
+    export const askFaucetIgniteCli = async (
+        address: string,
+        tokens: { [denom: string]: number },
+    ): Promise<string> =>
+        httpRequest(
+            process.env.FAUCET_URL,
+            { method: "POST" },
+            JSON.stringify({
+                address: address,
+                coins: Object.entries(tokens).map(([denom, value]) => value + denom),
+            }),
+        )
+    ```
+
+    </CodeGroupItem>
+
+    </CodeGroup>
+
+    <HighlightBox type="note">
+
+    * The CosmJS faucet API does **not** let you specify the desired amount.
+    * The Ignite faucet API lets you specify the desired amount.
+
+    </HighlightBox>
+
+3. A function that tries one faucet and if that one fails, tries the other:
+
+    ```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/src/util/faucet.ts#L24-L28]
+    export const askFaucet = async (
+        address: string,
+        tokens: { [denom: string]: number },
+    ): Promise<string | string[]> =>
+        askFaucetComsJs(address, tokens).catch(() => askFaucetIgniteCli(address, tokens))
+    ```
+
+You will find out with practice how many tokens your accounts need for the tests. Start with any value. Ignite's default configuration is to start a chain with two tokens: `stake` and `token`, this is a good default. You use both denoms.
+
+Create another `before` that will credit Alice and Bob from the faucet so that they are rich enough to continue:
+
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L54-L87]
 const aliceCredit = {
         stake: 100,
         token: 1,
@@ -394,21 +457,29 @@ const aliceCredit = {
     }
 
 before("credit test accounts", async function () {
-    this.timeout(20_000)
-    await askFaucet(alice, aliceCredit)
-    await askFaucet(bob, bobCredit)
-    expect(parseInt((await aliceClient.getBalance(alice, "stake")).amount, 10)).to.be.greaterThanOrEqual(
-        aliceCredit.stake,
-    )
-    expect(parseInt((await aliceClient.getBalance(alice, "token")).amount, 10)).to.be.greaterThanOrEqual(
-        aliceCredit.token,
-    )
-    expect(parseInt((await bobClient.getBalance(bob, "stake")).amount, 10)).to.be.greaterThanOrEqual(
-        bobCredit.stake,
-    )
-    expect(parseInt((await bobClient.getBalance(bob, "token")).amount, 10)).to.be.greaterThanOrEqual(
-        bobCredit.token,
-    )
+     this.timeout(40_000)
+        if (
+            parseInt((await aliceClient.getBalance(alice, "stake")).amount, 10) < aliceCredit.stake ||
+            parseInt((await aliceClient.getBalance(alice, "token")).amount, 10) < aliceCredit.token
+        )
+            await askFaucet(alice, aliceCredit)
+        expect(parseInt((await aliceClient.getBalance(alice, "stake")).amount, 10)).to.be.greaterThanOrEqual(
+            aliceCredit.stake,
+        )
+        expect(parseInt((await aliceClient.getBalance(alice, "token")).amount, 10)).to.be.greaterThanOrEqual(
+            aliceCredit.token,
+        )
+        if (
+            parseInt((await bobClient.getBalance(bob, "stake")).amount, 10) < bobCredit.stake ||
+            parseInt((await bobClient.getBalance(bob, "token")).amount, 10) < bobCredit.token
+        )
+            await askFaucet(bob, bobCredit)
+        expect(parseInt((await bobClient.getBalance(bob, "stake")).amount, 10)).to.be.greaterThanOrEqual(
+            bobCredit.stake,
+        )
+        expect(parseInt((await bobClient.getBalance(bob, "token")).amount, 10)).to.be.greaterThanOrEqual(
+            bobCredit.token,
+        )
 })
 ```
 
@@ -416,9 +487,9 @@ Your accounts are now ready to proceed with the tests proper.
 
 <HighlightBox type="note">
 
-There are an extra 20 seconds given for this potentially slower process: `this.timeout(20_000)`.
+There are an extra 40 seconds given for this potentially slower process: `this.timeout(40_000)`.
 
-You may want to adjust this time-out value. Here it is set at 10 seconds multiplied by the number of transactions in the function. Query calls are typically very fast and therefore need not enter in the time-out calculation.
+You may want to adjust this time-out value. Here it is set at 10 seconds multiplied by the maximum number of transactions in the function. Here there are at most 4 transactions when calling the CosmJS faucet. Query calls are typically very fast and therefore need not enter in the time-out calculation.
 
 </HighlightBox>
 
@@ -434,7 +505,7 @@ With a view to reusing them, add convenience methods that encapsulate the extrac
     export type GameCreatedEvent = Event
 
     export const getCreateGameEvent = (log: Log): GameCreatedEvent | undefined =>
-        log.events!.find((event: Event) => event.type === "new-game-created")
+        log.events?.find((event: Event) => event.type === "new-game-created")
 
     export const getCreatedGameId = (createdGameEvent: GameCreatedEvent): string =>
         createdGameEvent.attributes.find((attribute: Attribute) => attribute.key == "game-index")!.value
@@ -446,7 +517,7 @@ With a view to reusing them, add convenience methods that encapsulate the extrac
     export type MovePlayedEvent = Event
 
     export const getMovePlayedEvent = (log: Log): MovePlayedEvent | undefined =>
-        log.events!.find((event: Event) => event.type === "move-played")
+        log.events?.find((event: Event) => event.type === "move-played")
 
     export const getCapturedPos = (movePlayedEvent: MovePlayedEvent): Pos | undefined => {
         const x: number = parseInt(
@@ -477,7 +548,7 @@ With a view to reusing them, add convenience methods that encapsulate the extrac
 
 Start by creating a game, extracting its index from the logs, and confirming that you can fetch it.
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L81-L104]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L91-L112]
 let gameIndex: string
 
 it("can create game with wager", async function () {
@@ -506,7 +577,7 @@ it("can create game with wager", async function () {
 
 Next, add a test that confirms that the wager tokens are consumed on first play:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L106-L118]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L114-L126]
 it("can play first moves and pay wager", async function () {
     this.timeout(20_000)
     const aliceBalBefore = parseInt((await aliceClient.getBalance(alice, "token")).amount, 10)
@@ -612,12 +683,12 @@ Fortunately, the [`sign`](https://github.com/cosmos/cosmjs/blob/v0.28.11/package
 
 Because JavaScript has low assurances when it comes to threading, you need to make sure that each `sign` command happens after the previous one, or your `sequence` incrementing may get messed up. For that, you should not use `Promise.all` on something like `array.forEach(() => { await })`, which fires all promises roughly at the same time. Instead you will use a `while() { await }` pattern.
 
-There is a **second difficulty** when you want to send that many signed transactions. The client's `broadcastTx` function [waits for it](https://github.com/cosmos/cosmjs/blob/v0.28.11/packages/stargate/src/stargateclient.ts#L420-L424) to be included in a block, which would defeat the purpose of signing separately. Fortunately, if you look into its content, you can see that it calls [`this.forceGetTmClient().broadcastTxSync`](https://github.com/cosmos/cosmjs/blob/v0.28.11/packages/stargate/src/stargateclient.ts#L410). This Tendermint client function returns only [the transaction hash](https://github.com/cosmos/cosmjs/blob/v0.28.11/packages/tendermint-rpc/src/tendermint34/tendermint34client.ts#L172), that is _before any inclusion in a block_.
+There is a **second difficulty** when you want to send that many signed transactions. The client's `broadcastTx` function [waits for it](https://github.com/cosmos/cosmjs/blob/v0.28.11/packages/stargate/src/stargateclient.ts#L420-L424) to be included in a block, which would defeat the purpose of signing separately. Fortunately, if you look into the function's body, you can see that it calls [`this.forceGetTmClient().broadcastTxSync`](https://github.com/cosmos/cosmjs/blob/v0.28.11/packages/stargate/src/stargateclient.ts#L410). This Tendermint client function returns only [the transaction hash](https://github.com/cosmos/cosmjs/blob/v0.28.11/packages/tendermint-rpc/src/tendermint34/tendermint34client.ts#L172), that is _before any inclusion in a block_.
 
 On the other hand, you want the last transaction to be included in the block so that when you query for the stored game you get the expected values. Therefore you will:
 
 1. Send the first 21 signed transactions with the _fast_ `this.forceGetTmClient().broadcastTxSync`.
-2. Send the last transaction with a _slow_ client `broadcastTx`.
+2. Send the last signed transaction with a _slow_ client `broadcastTx`.
 
 Here again, you need to make sure that you submit all transactions in sequential manner, otherwise a player may in effect try to play before their turn. At this point, you have to trust that Tendermint includes the transactions in the order in which they were submitted. If Tendermint does any shuffling between Alice and Bob, you may end up with a "play before their turn" error.
 
@@ -631,7 +702,7 @@ You would use the same techniques if you wanted to stress test your blockchain. 
 
 Add a way to track the sequences of Alice and Bob:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L120-L130]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L128-L138]
 interface ShortAccountInfo {
     accountNumber: number
     sequence: number
@@ -647,7 +718,7 @@ const getShortAccountInfo = async (who: string): Promise<ShortAccountInfo> => {
 
 Add helpers to pick the right Alice or Bob values:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L131-L132]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L139-L140]
 const whoseClient = (who: Player) => (who == "b" ? aliceClient : bobClient)
 const whoseAddress = (who: Player) => (who == "b" ? alice : bob)
 ```
@@ -664,7 +735,7 @@ Note that this function is on the _read-only_ Stargate client. The signing Starg
 
 Create your `it` test with the necessary initializations:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L134-L141]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L142-L149]
 it("can continue the game up to before the double capture", async function () {
     this.timeout(20_000)
     const client: CheckersStargateClient = await CheckersStargateClient.connect(RPC_URL)
@@ -679,7 +750,7 @@ it("can continue the game up to before the double capture", async function () {
 
 Now get all 22 signed transactions, from index 2 to index 23:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L142-L175]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L150-L183]
 const txList: TxRaw[] = []
 let txIndex: number = 2
 while (txIndex < 24) {
@@ -730,7 +801,7 @@ Note how:
 
 With all the transactions signed, you can _fire_ broadcast the first 21 of them:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L177-L183]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L185-L191]
 const hashes: BroadcastTxSyncResponse[] = []
 txIndex = 0
 while (txIndex < txList.length - 1) {
@@ -742,7 +813,7 @@ while (txIndex < txList.length - 1) {
 
 You now _normally_ broadcast the last one:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L185-L187]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L193-L195]
 const lastDelivery: DeliverTxResponse = await client.broadcastTx(
     TxRaw.encode(txList[txList.length - 1]).finish(),
 )
@@ -750,7 +821,7 @@ const lastDelivery: DeliverTxResponse = await client.broadcastTx(
 
 If you are interested, you can log the blocks in which the transactions were included:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L189-L195]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L197-L203]
 console.log(
     txList.length,
     "transactions included in blocks from",
@@ -762,7 +833,7 @@ console.log(
 
 Lastly, make sure that the game has the expected board:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L197-L198]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L205-L206]
 const game: StoredGame = (await checkers.getStoredGame(gameIndex))!
 expect(game.board).to.equal("*b*b***b|**b*b***|***b***r|********|***r****|********|***r****|r*B*r*r*")
 ```
@@ -775,7 +846,7 @@ Alice, the black player can capture [two pieces in one turn](https://github.com/
 
 You are now ready to send that one transaction with the two messages with the use of `signAndBroadcast`. Add an `it` test with the right initializations:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L202-L204]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L209-L212]
 it("can send a double capture move", async function () {
     this.timeout(10_000)
     const firstCaptureMove: GameMove = completeGame[24]
@@ -786,7 +857,7 @@ it("can send a double capture move", async function () {
 
 In it, make the call with the correctly crafted messages.
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L205-L232]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L213-L240]
 const response: DeliverTxResponse = await aliceClient.signAndBroadcast(
     alice,
     [
@@ -819,7 +890,7 @@ const response: DeliverTxResponse = await aliceClient.signAndBroadcast(
 
 Next, collect the events and confirm they match your expectations:
 
-```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L233-L242]
+```typescript [https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L241-L250]
 const logs: Log[] = JSON.parse(response.rawLog!)
 expect(logs).to.be.length(2)
 expect(getCapturedPos(getMovePlayedEvent(logs[0])!)).to.deep.equal({
@@ -843,24 +914,98 @@ Sending a single transaction with two moves is cheaper and faster, from the poin
 <HighlightBox type="note">
 
 It is not possible for Alice, who is the creator and black player, to send in a single transaction a message for creation and a message to make the first move on it. That's because the index of the game is not known before the transaction has been included in a block, and with that the index computed.
-<br/><br/>
+
+</HighlightBox>
+
+<HighlightBox type="warn">
+
 Of course, she could try, but if her move failed because of a wrong game id then the whole transaction would revert, and that would include the game creation being reverted.
+<br/><br/>
+Worse, a malicious attacker could **front-run** Alice's transaction with another transaction, creating a game where Alice is also the black player and whose id ends up being the one Alice signed in her first move. In the end she would make the first move on a game she did not really intend to play. This game could even have a wager that is _all_ of Alice's token holdings.
 
 </HighlightBox>
 
 ### Further tests
 
-You can add further tests, for instance to see what happens with token balances when you continue playing the game [up to its completion](https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L245-L312).
+You can add further tests, for instance to see what happens with token balances when you continue playing the game [up to its completion](https://github.com/cosmos/academy-checkers-ui/blob/signing-stargate/test/integration/stored-game-action.ts#L253-L321).
+
+### Prepare your checkers chain
+
+If you launch the tests just like you did in the [previous section](/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md), you may be missing a faucet.
+
+Adjust what you did. 
+
+* If you came here after going through the rest of the hands-on exercise, you know how to launch a running chain with Ignite, which has a faucet to start with.
+* If you arrived here and are only focussed on learning CosmJS, it is possible to abstract away niceties of both the running chain and a faucet in a minimal package. For this, you need Docker and to create an image:
+
+   1. Get the `Dockerfile`:
+
+       ```sh
+       $ curl -O https://github.com/cosmos/b9-checkers-academy-draft/blob/run-prod/Dockerfile-standalone
+       ```
+
+   2. Build the checkers image:
+
+       ```sh
+       $ docker build . \
+           -f Dockerfile-standalone \
+           -t checkersd_i:standalone
+       ```
+
+    3. Build the CosmJS faucet image:
+
+        ```sh
+        $ docker build . \
+            -f Dockerfile-standalone \
+            --target cosmos-faucet \
+            -t cosmos-faucet_i:0.28.11
+        ```
+
+If you have another preferred method, make sure to adjust your above `RPC_URL` and `FAUCET_URL` accordingly.
+
+<HighlightBox type="tip">
+
+If you are curious about how this `Dockerfile-standalone` was created, head to the [run in production](../4-run-in-prod/1-run-prod-docker.md) section.
+
+</HighlightBox>
 
 ### Launch the tests
 
-You launch the tests just like you did in the [previous section](/hands-on-exercise/3-cosmjs-adv/1-cosmjs-objects.md).
-
-For instance, in the checkers (Go) blockchain folder:
+Launch your checkers chain and the faucet. You can choose your preferred method as long as they can be accessed at the `RPC_URL` and `FAUCET_URL` you defined earlier. For the purposes of this exercise, you have the choice between three methods:
 
 <CodeGroup>
 
-<CodeGroupItem title="Local" active>
+<CodeGroupItem title="Docker standalone" active>
+
+```sh
+$ docker run --rm -it \
+    -p 26657:26657 \
+    --name checkers \
+    --network checkers-net \
+    --detach \
+    checkersd_i:standalone start
+$ sleep 10
+$ docker run --rm -it \
+    -p 4500:4500 \
+    --name cosmos-faucet \
+    --network checkers-net \
+    --detach \
+    cosmos-faucet_i:0.28.11 start http://checkers:26657
+$ sleep 20
+```
+
+<HighlightBox type="note">
+
+* The names match those given in `RPC_URL` and `FAUCET_URL`.
+* The chain needs about 10 seconds to start listening on port 26657. The faucet does not _retry_ so you have to be sure the chain is started.
+* The faucet container itself takes about 20 seconds to be operational as it creates 4 transactions in 4 blocks.
+* Their are started in `--detach`ed mode, but you are free to start them attached in different shells.
+
+</HighlightBox>
+
+</CodeGroupItem>
+
+<CodeGroupItem title="Local Ignite">
 
 ```sh
 $ ignite chain serve
@@ -868,24 +1013,34 @@ $ ignite chain serve
 
 </CodeGroupItem>
 
-<CodeGroupItem title="Docker">
+<CodeGroupItem title="Docker Ignite">
 
 ```sh
-$ docker network create checkers-net
 $ docker run --rm -it \
     -v $(pwd):/checkers \
     -w /checkers \
+    -p 4500:4500 \
+    -p 26657:26657 \
     --network checkers-net \
-    --name chain-serve \
+    --name checkers \
+    --network-alias cosmos-faucet \
     checkers_i \
     ignite chain serve
 ```
+
+<HighlightBox type="note">
+
+* The name and alias match those given in `RPC_URL` and `FAUCET_URL` respectively.
+
+</HighlightBox>
 
 </CodeGroupItem>
 
 </CodeGroup>
 
-Now if you run the tests:
+---
+
+Now you can run the tests:
 
 <CodeGroup>
 
@@ -894,6 +1049,12 @@ Now if you run the tests:
 ```sh
 $ npm test
 ```
+
+<HighlightBox type="info">
+
+Remember that `RPC_URL` and `FAUCET_URL` have to mention `localhost` in this case.
+
+</HighlightBox>
 
 </CodeGroupItem>
 
@@ -908,12 +1069,25 @@ $ docker run --rm \
     npm test
 ```
 
-Do not forget to replace `localhost` by `chain-serve` in `.env`.
+<HighlightBox type="info">
+
+Remember that `RPC_URL` and `FAUCET_URL` have to mention `checkers` and `cosmos-faucet` respectively in this case.
+
+</HighlightBox>
 
 </CodeGroupItem>
 
 </CodeGroup>
 
+---
+
+The only combination of running chain / running tests that will not work is if you run Ignite on your local computer and the tests in a container. For this edge case, you should put your host IP address in `RPC_URL` and `FAUCET_URL`.
+
+When you are done, if you started the chain in Docker, you can stop the containers with:
+
+```sh
+$ docker stop cosmos-faucet checkers
+```
 
 <HighlightBox type="synopsis">
 

--- a/hands-on-exercise/3-cosmjs-adv/4-cosmjs-gui.md
+++ b/hands-on-exercise/3-cosmjs-adv/4-cosmjs-gui.md
@@ -20,8 +20,8 @@ Make sure you have all you need before proceeding:
 
 In the previous sections:
 
-1. You created the [objects](./1-cosmjs-objects.md), [messages, and clients](./2-cosmjs-messages.md) that allow you to **interface** any GUI with your checkers blockchain.
-2. You learned how to [start a running checkers blockchain](./2-cosmjs-messages.md#prepare-your-checkers-chain) in Docker or on your local computer.
+1. You created the [objects](./1-cosmjs-objects.md), and the [messages and clients](./2-cosmjs-messages.md) that allow you to **interface** any GUI with your checkers blockchain.
+2. You learned how to [start a running checkers blockchain](./2-cosmjs-messages.md#prepare-your-checkers-chain), in Docker or on your local computer.
 3. You imported an external checkers **GUI** to use.
 
 Now, you must **integrate the two** together:
@@ -40,7 +40,7 @@ For the CosmJS integration, you will:
 
 This exercise assumes that:
 
-1. You are running your [checkers blockchain with](./2-cosmjs-messages.md#prepare-your-checkers-chain):
+1. You are running your [checkers blockchain](./2-cosmjs-messages.md#prepare-your-checkers-chain) with:
 
     ```sh
     $ docker run --rm -it \
@@ -620,7 +620,7 @@ Refresh the page to confirm the change.
 
 ## Integrate with Keplr
 
-So far you have _only_ made it possible to show the state of games and of the blockchain. This allows your users to poke around without unnecessarily asking them to connect their wallet and thereby disclose their address. However, to create a game or play in one, you need to make transactions. This is where you need to make integration with the Keplr wallet possible.
+So far you have _only_ made it possible to show the state of games and of the blockchain. This allows your users to poke around without unnecessarily asking them to connect their wallet and thereby disclose their address. However, to create a game or play in one, users need to make transactions. This is where you need to make integration with the Keplr wallet possible.
 
 Install the necessary packages:
 

--- a/hands-on-exercise/3-cosmjs-adv/5-server-side.md
+++ b/hands-on-exercise/3-cosmjs-adv/5-server-side.md
@@ -18,7 +18,7 @@ Make sure you have all you need before proceeding:
 
 This exercise assumes that:
 
-1. You are running your [checkers blockchain with](./2-cosmjs-messages.md#prepare-your-checkers-chain):
+1. You are running your [checkers blockchain](./2-cosmjs-messages.md#prepare-your-checkers-chain) with:
 
     ```sh
     $ docker run --rm -it \
@@ -37,7 +37,7 @@ This exercise assumes that:
     $ sleep 20
     ```
 
-2. And have the following in `.env`:
+2. You have the following in `.env`:
 
     <CodeGroup>
     
@@ -1019,7 +1019,7 @@ Forfeit game: 1, black: cosmos1am3fnp5dd6nndk5jyjq9mpqh3yvt2jmmdv83xn, red: cosm
 
 <HighlightBox type="tip">
 
-In the standalone checkers in Docker, the deadline is unfortunately set at 24 hours, so feedback is not coming exactly fast. At this state of the exercise, if you want to test the expiry quickly, you will have to run Ignite CLI and adjust the `MaxTurnDuration` as described [here](../2-ignite-cli-adv/4-game-forfeit.mdl#interact-via-the-cli).
+In the standalone checkers in Docker, the deadline is unfortunately set at 24 hours, so feedback is not exactly coming fast. At this state of the exercise, if you want to test the expiry quickly, you will have to run Ignite CLI and adjust the `MaxTurnDuration` as described [here](../2-ignite-cli-adv/4-game-forfeit.mdl#interact-via-the-cli).
 
 </HighlightBox>
 

--- a/hands-on-exercise/4-run-in-prod/1-run-prod-docker.md
+++ b/hands-on-exercise/4-run-in-prod/1-run-prod-docker.md
@@ -1623,7 +1623,7 @@ Now may be a good time to prepare a standalone setup that can be used by anyone 
 * It also provides a faucet to further facilitate tests.
 * It sacrifices key safety to increase ease of use.
 
-The CosmJS exercise already references this standalone `Dockerfile`, so this is a circular reference. You can still on it on your own now.
+The CosmJS exercise already references this standalone `Dockerfile`, so this is a circular reference. You can still work on it on your own now.
 
 It is possible to build [more than one Docker image](https://docs.docker.com/build/building/multi-stage/#stop-at-a-specific-build-stage) out of a single `Dockerfile` by using the multi-stage build mechanism.
 

--- a/hands-on-exercise/4-run-in-prod/1-run-prod-docker.md
+++ b/hands-on-exercise/4-run-in-prod/1-run-prod-docker.md
@@ -1987,6 +1987,7 @@ With your images built, you can launch both `checkersd` and the faucet process r
 <CodeGroupItem title="Checkers">
 
 ```sh
+$ docker network create checkers-net
 $ docker run --rm -it \
     -p 26657:26657 \
     --name checkers \
@@ -1996,6 +1997,14 @@ $ docker run --rm -it \
 ```
 
 Checkers needs about **10 seconds** to be operational. Wait for that before launching the faucet.
+
+If your `checkers-net` network already exists, the first command fails with:
+
+```txt
+Error response from daemon: network with name checkers-net already exists
+```
+
+But that is ok.
 
 </CodeGroupItem>
 
@@ -2103,6 +2112,7 @@ And to stop (and `--rm`) both containers, run:
 
 ```sh
 $ docker stop cosmos-faucet checkers
+$ docker network rm checkers-net
 ```
 
 <HighlightBox type="synopsis">

--- a/hands-on-exercise/4-run-in-prod/1-run-prod-docker.md
+++ b/hands-on-exercise/4-run-in-prod/1-run-prod-docker.md
@@ -1620,16 +1620,16 @@ Now may be a good time to prepare a standalone setup that can be used by anyone 
 * The `Dockerfile` does not need to be in the repository to be usable. It could be copied elsewhere and still work, i.e. no `ADD`ing local files. 
 * The image(s) should be as small as is reasonable.
 * It uses `stake` instead of `upawn`, and has `token` so as to be compatible with the current state of the checkers CosmJS exercise.
-* It also provides a faucet to further facilitates tests.
-* It sacrifices keys safety to increase ease of use.
+* It also provides a faucet to further facilitate tests.
+* It sacrifices key safety to increase ease of use.
 
-The CosmJS exercise already references this standalone `Dockerfile` so this is a circular reference. You can still on it on your own now.
+The CosmJS exercise already references this standalone `Dockerfile`, so this is a circular reference. You can still on it on your own now.
 
 It is possible to build [more than one Docker image](https://docs.docker.com/build/building/multi-stage/#stop-at-a-specific-build-stage) out of a single `Dockerfile` by using the multi-stage build mechanism.
 
 ### CosmJS faucet
 
-When running `ignite chain serve`, you also get a faucet, which was called when running [CosmJS integration tests](../3-cosmjs-adv/2-cosmjs-messages.md#adding-tests). In fact, CosmJS also offers a [faucet package](https://www.npmjs.com/package/@cosmjs/faucet). Its API differs from Ignite's faucet. If you went through the CosmJS exercise, you saw its API being called too.
+When running `ignite chain serve` you also get a faucet, which was called when running the [CosmJS integration tests](../3-cosmjs-adv/2-cosmjs-messages.md#adding-tests). In fact, CosmJS also offers a [faucet package](https://www.npmjs.com/package/@cosmjs/faucet). Its API differs from Ignite's faucet. If you went through the CosmJS exercise, you saw its API being called too.
 
 ### Dockerfile construction, checkers
 
@@ -1639,7 +1639,7 @@ You assemble this multi-stage `Dockerfile` step by step, starting with the check
 
 <PanelListItem number="1">
 
-Build the checkers executable as you have learned in this section, but this time from the public repository, so as to not depend on local files:
+Build the checkers executable as you have learned in this section, but this time from the public repository so as to not depend on local files:
 
 ```Dockerfile
 FROM --platform=linux golang:1.18.7-alpine AS builder
@@ -1663,7 +1663,7 @@ COPY --from=builder /root/checkers/build/checkersd /usr/local/bin/checkersd
 
 <PanelListItem number="2">
 
-To offer maximum determinism, you are going to reuse unprotected keys. First you need to create them with `checkersd` separately, somewhere _unimportant_, like a temporary container:
+To offer maximum determinism, you are going to reuse unprotected keys. First you need to create them with `checkersd` separately, somewhere _unimportant_ like a temporary container:
 
 ```sh
 $ checkersd keys add alice --keyring-backend test
@@ -1720,7 +1720,7 @@ fOM6ZNruv1AirP/KYq1ZdMLdp8ynpk4cGPCsNThmEvRvqkhONpo9S1+tw6/WiFRN
 -----END TENDERMINT PRIVATE KEY-----
 ```
 
-So you add it as a local file in `Dockerfile`:
+Next, add it as a local file in `Dockerfile`:
 
 ```diff
     ENV ALICE=cosmos1am3fnp5dd6nndk5jyjq9mpqh3yvt2jmmdv83xn
@@ -1739,7 +1739,7 @@ So you add it as a local file in `Dockerfile`:
 +  RUN echo -----END TENDERMINT PRIVATE KEY----- >> /root/.checkers/keys/encrypted-private-key-alice.txt
 ```
 
-And then import it:
+Now import it:
 
 ```diff
     RUN echo -----END TENDERMINT PRIVATE KEY----- >> /root/.checkers/keys/encrypted-private-key-alice.txt
@@ -1751,7 +1751,7 @@ And then import it:
 
 <PanelListItem number="4">
 
-Then you create a genesis as you learned in this section, while making sure the other configuration files are also configured permissively:
+You then create a genesis as you learned in this section, while making sure the other configuration files are also configured permissively:
 
 ```diff
     RUN echo password | checkersd keys import alice /root/.checkers/keys/encrypted-private-key-alice.txt --keyring-backend test
@@ -1773,14 +1773,14 @@ Then you create a genesis as you learned in this section, while making sure the 
 
 Note that:
 
-* You add both `stake` and `token` to Alice so as to increase compatibility with the CosmJS exercise.
+* You add both `stake` and `token` to Alice, so as to increase compatibility with the CosmJS exercise.
 * The genesis transaction is only with `stake`.
 
 </PanelListItem>
 
 <PanelListItem number="5" :last="true">
 
-Finally, you advertise the gRPC port so that any user know they ought to forward to the host; and have `checkersd` start by default:
+Finally, advertise the gRPC port so that any user knows they ought to forward to the host, and have `checkersd` start by default:
 
 ```diff
     RUN checkersd collect-gentxs
@@ -1804,7 +1804,7 @@ Moving on to the faucet, you continue adding to the same `Dockerfile`.
 
 <PanelListItem number="1">
 
-You start its definitino as a separate independent stage:
+You start its definition as a separate independent stage:
 
 ```Dockerfile
 FROM --platform=linux node:18.7-alpine AS cosmos-faucet
@@ -1840,12 +1840,16 @@ Configure the faucet:
 +  ENV FAUCET_COOLDOWN_TIME=0
 ```
 
-Of note:
+<HighlightBox type="note">
 
-* A concurrency of at least `2` is necessary for the CosmJS exercise because when crediting in `before`, it launches two simultaneous requests. The faucet does **not** internally keep track of the accounts' sequences and instead uses its _distributor_ accounts in a round-robin fashion.
-* Use port 4500 to mimic that of Ignite's faucet so as to be conveniently compatible with the CosmJS exercise.
-* You paste the mnemonic that you obtained in the previous key-creation steps.
-* You reuse the token denominations as found in the CosmJS exercise.
+Be aware:
+
+* A concurrency of at least `2` is necessary for the CosmJS exercise, because when crediting in `before` it launches two simultaneous requests. The faucet does **not** internally keep track of the accounts' sequences and instead uses its _distributor_ accounts in a round-robin fashion.
+* You used port 4500 to mimic that of Ignite's faucet, so as to be conveniently compatible with the CosmJS exercise.
+* You pasted the mnemonic that you obtained in the previous key-creation steps.
+* You reused the token denominations as found in the CosmJS exercise.
+
+</HighlightBox>
 
 </PanelListItem>
 
@@ -1996,7 +2000,7 @@ $ docker run --rm -it \
     checkersd_i:standalone start
 ```
 
-Checkers needs about **10 seconds** to be operational. Wait for that before launching the faucet.
+Checkers needs about **10 seconds** to become operational. Wait that long before launching the faucet.
 
 If your `checkers-net` network already exists, the first command fails with:
 
@@ -2004,7 +2008,7 @@ If your `checkers-net` network already exists, the first command fails with:
 Error response from daemon: network with name checkers-net already exists
 ```
 
-But that is ok.
+But that is okay.
 
 </CodeGroupItem>
 
@@ -2019,7 +2023,7 @@ $ docker run --rm -it \
     cosmos-faucet_i:0.28.11 start http://checkers:26657
 ```
 
-The faucet needs about **20 seconds** to be operational as it sends four transactions to its distributor accounts. Wait for that before launching any CosmJS tests.
+The faucet needs about **20 seconds** to become operational, as it sends four transactions to its distributor accounts. Wait that long before launching any CosmJS tests.
 
 </CodeGroupItem>
 
@@ -2027,10 +2031,14 @@ The faucet needs about **20 seconds** to be operational as it sends four transac
 
 ---
 
-Note how:
+<HighlightBox type="note">
 
-* Both processes are started as `--detach`ed, which is how it is typically started by users who do not care about the details. If you get errors, then stop, remove this flag and restart to see the logs.
+Be aware:
+
+* Both processes are started as `--detach`ed, which is how they are typically started by users who do not care about the details. If you get errors then stop, remove this flag, and restart to see the logs.
 * Checkers is started with `--name checkers`, whose name is then reused in the node address `http://checkers:26657` when launching the faucet.
+
+</HighlightBox>
 
 On a side-note, if you want to access Alice's address in order to access her balance, you can run:
 
@@ -2039,7 +2047,7 @@ $ docker exec -it checkers \
     sh -c "checkersd query bank balances \$ALICE"
 ```
 
-And to check the faucet status, you can do:
+And to check the faucet status, you can use:
 
 ```sh
 $ curl http://localhost:4500/status
@@ -2100,7 +2108,7 @@ $ docker run --rm -it \
     npm test
 ```
 
-Note how the container is inserted in `--network checkers-net` too, so as to benefit from the automatic name resolution.
+Note how the container is also inserted in `--network checkers-net`, so as to benefit from the automatic name resolution.
 
 </CodeGroupItem>
 
@@ -2108,7 +2116,7 @@ Note how the container is inserted in `--network checkers-net` too, so as to ben
 
 ---
 
-And to stop (and `--rm`) both containers, run:
+To stop (and `--rm`) both containers, run:
 
 ```sh
 $ docker stop cosmos-faucet checkers
@@ -2124,7 +2132,7 @@ To summarize, this section has explored:
 * How to prepare a Tendermint Key Management System for a simulated production setup.
 * How to prepare a blockchain genesis with multiple parties.
 * How to launch all that with the help of Docker Compose.
-* How to create a standalone blochain server in a container.
+* How to create a standalone blockchain server in a container.
 * How to create a small faucet to assist with running your CosmJS integration tests.
 
 </HighlightBox>


### PR DESCRIPTION
Up to now, the CosmJS hands-on exercise was asking the student to run Ignite to test. This is heavy and works for IDA students. On the other hand, it risks discouraging purely Javascript developers that cannot be bothered with the Go code.

This PR introduces and makes use of the new _standalone_ checkers + faucet so that Javascript developers can be up and running fast:

* 1 Dockerfile that can be downloaded with `curl`.
* 1 checkers Docker image of 85 MB to build in 10 minutes (with about 300 MB of downloads I think)
* 1 faucet Docker image of 210 MB to build in 1 minute.

Eventually, we can consider adding a similar file to the Cosmos SDK repo, adapted for SimApp, so that CosmJS students can work simply,.

### R1: Internal review (B9lab)

- Technical review
  - [x] requested
  - [x] completed
- Language review
  - [x] requested
  - [x] completed

### R2: External review

- Technical review
  - [x] requested
  - [x] completed
- Language review
  - [x] requested
  - [x] completed

### R3: Internal QA review (B9lab)

- Technical review
  - [ ] requested
  - [ ] completed
- Language review
  - [ ] requested
  - [ ] completed

### R4: Final external QA review

- Technical review
  - [ ] requested
  - [ ] completed
- Language review
  - [ ] requested
  - [ ] completed

### RC: Release Candidate

- [ ] Ready to be merged

