### PR TITLE
fix wrong github source url in hands-on-exercise

### DIFF
--- a/hands-on-exercise/1-ignite-cli/8-game-winner.md
+++ b/hands-on-exercise/1-ignite-cli/8-game-winner.md
@@ -195,7 +195,7 @@ Add [tests](https://github.com/cosmos/b9-checkers-academy-draft/blob/game-winner
 
 You also need to update your existing tests so that they pass with a new `Winner` value. Most of your tests need to add this line:
 
-```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-winner/x/checkers/keeper/msg_server_play_moveo_test.go#L107]
+```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-winner/x/checkers/keeper/msg_server_play_move_test.go#L107]
     ...
     require.EqualValues(t, types.StoredGame{
         ...


### PR DESCRIPTION

Documentation content update for [hands on exercise, Record the Game Winner]

This PR fix wrong github soruce url

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [x] Small language/grammar fixes
* [ ] Small content fixes 
* [ ] Addition of new content
* [ ] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
