### PR TITLE
fix: (8-game-winner.md) wrong code and link

### DIFF
--- a/hands-on-exercise/1-ignite-cli/8-game-winner.md
+++ b/hands-on-exercise/1-ignite-cli/8-game-winner.md
@@ -115,10 +115,10 @@ This is a two-part update. You set the winner where relevant, but you also intro
 
 Start with a new error that you define as a constant:
 
-```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-winner/x/checkers/types/errors.go#L18]
+```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-winner/x/checkers/types/errors.go#L21]
     var (
         ...
-+      ErrGameFinished = sdkerrors.Register(ModuleName, 1107, "game is already finished")
++      ErrGameFinished = sdkerrors.Register(ModuleName, 1110, "game is already finished")
     )
 ```
 
@@ -195,7 +195,7 @@ Add [tests](https://github.com/cosmos/b9-checkers-academy-draft/blob/game-winner
 
 You also need to update your existing tests so that they pass with a new `Winner` value. Most of your tests need to add this line:
 
-```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-winner/x/checkers/keeper/msg_server_play_moveo_test.go#L107]
+```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/game-winner/x/checkers/keeper/msg_server_play_move_test.go#L107]
     ...
     require.EqualValues(t, types.StoredGame{
         ...


### PR DESCRIPTION
Documentation content update for hands-on-exercise/1-ignitecli/8-game-winner.md

This PR fixes misspellings of a link file and sample code mismatching.

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [ ] Small language/grammar fixes
* [x] Small content fixes 
* [ ] Addition of new content
* [x] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
