### PR TITLE
ac-docs-minor-typo-fix

### DIFF
--- a/academy/3-ibc/6-solomachine.md
+++ b/academy/3-ibc/6-solomachine.md
@@ -1,6 +1,6 @@
 ---
 title: "IBC Solo Machine"
-order: 9
+order: 7
 description: Solo machine client
 tags:
   - concepts

--- a/hands-on-exercise/4-run-in-prod/5-migration-prod.md
+++ b/hands-on-exercise/4-run-in-prod/5-migration-prod.md
@@ -1,5 +1,5 @@
 ---
-title: "Simulate a migration in production in Docker"
+title: "Simulate a Migration in Docker"
 order: 6
 description: Introduce the leaderboard in a simulated production setup with Docker Compose
 tags: 
@@ -8,7 +8,7 @@ tags:
   - dev-ops
 ---
 
-# Simulate a migration in Docker
+# Simulate a Migration in Docker
 
 <HighlightBox type="prerequisite">
 

--- a/ida-customizations/ida-course/exercise-week2.md
+++ b/ida-customizations/ida-course/exercise-week2.md
@@ -133,7 +133,7 @@ Please push your exercise solution to the [Week 2 Exercise repo](https://git.aca
 
 <HighlightBox type="note">
 
-**We recommend you attempt the exercise as soon as you finish the week's material, or by by Thursday, June 1st, 11:59pm UTC.**
+**We recommend you attempt the exercise as soon as you finish the week's material, or by Thursday, June 1st, 11:59pm UTC.**
 <br/><br/>
 Do not worry if you do not pass the exercise: it is simply meant to be an opportunity to practice and demonstrate your engagement with the program.
 

--- a/ida-customizations/ida-course/quiz-week1.md
+++ b/ida-customizations/ida-course/quiz-week1.md
@@ -14,7 +14,7 @@ Follow this link: [Week 1 Quiz](https://hr.gs/ida-c4-week1-quiz), to submit a po
 
 <HighlightBox type="note">
 
-**We recommend you attempt the quiz as soon as you finish the week's material, or by by Thursday, June 1st, 11:59pm UTC.** 
+**We recommend you attempt the quiz as soon as you finish the week's material, or by Thursday, June 1st, 11:59pm UTC.** 
 <br/><br/>
 We highly recommend submitting the quiz as an opportunity to practice and demonstrate your engagement with the program.
 <br/><br/>


### PR DESCRIPTION
Correction of copy-paste error in Week 1 Quiz and Week 2 Exercise pages

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [X] Small language/grammar fixes
* [ ] Small content fixes 
* [ ] Addition of new content
* [ ] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
