### PR TITLE
Update `types/genesis_test.go` with head/tail fifo index init values

### DIFF
--- a/hands-on-exercise/2-ignite-cli-adv/3-game-fifo.md
+++ b/hands-on-exercise/2-ignite-cli-adv/3-game-fifo.md
@@ -323,20 +323,21 @@ You have implemented a FIFO that is updated but never really used. It will be us
 
 At this point, your previous unit tests are failing, so they must be fixed. Add `FifoHeadIndex` and `FifoTailIndex` in your value requirements on `SystemInfo` as you [create games](https://github.com/cosmos/b9-checkers-academy-draft/blob/game-fifo/x/checkers/keeper/msg_server_create_game_test.go#L46-L47) and [play moves](https://github.com/cosmos/b9-checkers-academy-draft/blob/game-fifo/x/checkers/keeper/msg_server_play_move_test.go#L98-L99). Also add `BeforeIndex` and `AfterIndex` in your value requirements on `StoredGame` as you [create games](https://github.com/cosmos/b9-checkers-academy-draft/blob/game-fifo/x/checkers/keeper/msg_server_create_game_test.go#L60-L61) and [play moves](https://github.com/cosmos/b9-checkers-academy-draft/blob/game-fifo/x/checkers/keeper/msg_server_play_move_test.go#L112-L113).
 
-Edit `types/genesis_test.go`, so that it incorporates the newly added fields `FifoHeadIndex` and `FifoTailIndex` with the correct initialization values.
+Edit `types/genesis_test.go`, so that it incorporates the newly added fields `FifoHeadIndex` and `FifoTailIndex` with the correct initialization values:
 
-```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/fifo-fields/x/checkers/types/genesis_test.go#L71-L75]
-func TestDefaultGenesisState_ExpectedInitialNextId(t *testing.T) {
-	require.EqualValues(t,
-		&types.GenesisState{
-			StoredGameList: []types.StoredGame{},
-	+		SystemInfo: types.SystemInfo{
-	+			NextId:        uint64(1),
-	+			FifoHeadIndex: "-1",
-	+			FifoTailIndex: "-1",
-	+		},
-		},
-		types.DefaultGenesis())
+```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/fifo-fields/x/checkers/types/genesis_test.go#L71-L75]
+    func TestDefaultGenesisState_ExpectedInitialNextId(t *testing.T) {
+        require.EqualValues(t,
+            &types.GenesisState{
+                StoredGameList: []types.StoredGame{},
+-               SystemInfo:     types.SystemInfo{uint64(1)}, 
++               SystemInfo:     types.SystemInfo{
++               NextId:        uint64(1),
++               FifoHeadIndex: "-1",
++               FifoTailIndex: "-1",
++           },
+        },
+        types.DefaultGenesis())
     }
 ```
 

--- a/hands-on-exercise/2-ignite-cli-adv/3-game-fifo.md
+++ b/hands-on-exercise/2-ignite-cli-adv/3-game-fifo.md
@@ -188,23 +188,6 @@ How do you implement a FIFO from which you extract elements at random positions?
         }
     ```
 
-6. Adjust the types genesis test, so that it incorporates the newly added fields FifoHeadIndex and FifoTailIndex with the correct initialization values.
-
-    ```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/fifo-fields/x/checkers/types/genesis_test.go#L71-L75]
-    func TestDefaultGenesisState_ExpectedInitialNextId(t *testing.T) {
-	require.EqualValues(t,
-		&types.GenesisState{
-			StoredGameList: []types.StoredGame{},
-	+		SystemInfo: types.SystemInfo{
-	+			NextId:        uint64(1),
-	+			FifoHeadIndex: "-1",
-	+			FifoTailIndex: "-1",
-	+		},
-		},
-		types.DefaultGenesis())
-        }
-    ```
-
 ## FIFO management
 
 Now that the new fields are created, you need to update them to keep your FIFO up-to-date. It's better to create a separate file that encapsulates this knowledge. Create `x/checkers/keeper/stored_game_in_fifo.go` with the following:
@@ -339,6 +322,23 @@ You have implemented a FIFO that is updated but never really used. It will be us
 ## Unit tests
 
 At this point, your previous unit tests are failing, so they must be fixed. Add `FifoHeadIndex` and `FifoTailIndex` in your value requirements on `SystemInfo` as you [create games](https://github.com/cosmos/b9-checkers-academy-draft/blob/game-fifo/x/checkers/keeper/msg_server_create_game_test.go#L46-L47) and [play moves](https://github.com/cosmos/b9-checkers-academy-draft/blob/game-fifo/x/checkers/keeper/msg_server_play_move_test.go#L98-L99). Also add `BeforeIndex` and `AfterIndex` in your value requirements on `StoredGame` as you [create games](https://github.com/cosmos/b9-checkers-academy-draft/blob/game-fifo/x/checkers/keeper/msg_server_create_game_test.go#L60-L61) and [play moves](https://github.com/cosmos/b9-checkers-academy-draft/blob/game-fifo/x/checkers/keeper/msg_server_play_move_test.go#L112-L113).
+
+Edit `types/genesis_test.go`, so that it incorporates the newly added fields `FifoHeadIndex` and `FifoTailIndex` with the correct initialization values.
+
+```go [https://github.com/cosmos/b9-checkers-academy-draft/blob/fifo-fields/x/checkers/types/genesis_test.go#L71-L75]
+func TestDefaultGenesisState_ExpectedInitialNextId(t *testing.T) {
+	require.EqualValues(t,
+		&types.GenesisState{
+			StoredGameList: []types.StoredGame{},
+	+		SystemInfo: types.SystemInfo{
+	+			NextId:        uint64(1),
+	+			FifoHeadIndex: "-1",
+	+			FifoTailIndex: "-1",
+	+		},
+		},
+		types.DefaultGenesis())
+    }
+```
 
 Next, you should add more specific FIFO tests. For instance, testing what happens to `SystemInfo` and `StoredGame` as you create up to three new games, instead of [only checking at the end](https://github.com/cosmos/b9-checkers-academy-draft/blob/game-fifo/x/checkers/keeper/msg_server_create_game_test.go#L165-L232):
 

--- a/hands-on-exercise/2-ignite-cli-adv/3-game-fifo.md
+++ b/hands-on-exercise/2-ignite-cli-adv/3-game-fifo.md
@@ -188,6 +188,23 @@ How do you implement a FIFO from which you extract elements at random positions?
         }
     ```
 
+6. Adjust the types genesis test, so that it incorporates the newly added fields FifoHeadIndex and FifoTailIndex with the correct initialization values.
+
+    ```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/fifo-fields/x/checkers/types/genesis_test.go#L71-L75]
+    func TestDefaultGenesisState_ExpectedInitialNextId(t *testing.T) {
+	require.EqualValues(t,
+		&types.GenesisState{
+			StoredGameList: []types.StoredGame{},
+	+		SystemInfo: types.SystemInfo{
+	+			NextId:        uint64(1),
+	+			FifoHeadIndex: "-1",
+	+			FifoTailIndex: "-1",
+	+		},
+		},
+		types.DefaultGenesis())
+        }
+    ```
+
 ## FIFO management
 
 Now that the new fields are created, you need to update them to keep your FIFO up-to-date. It's better to create a separate file that encapsulates this knowledge. Create `x/checkers/keeper/stored_game_in_fifo.go` with the following:


### PR DESCRIPTION
**Instructions:** Please fill out the following items in brackets `[ ]`, check all items in the change scope list below and remove this line before submitting your Pull Request.

Documentation content update for [Module X, Section Y]

This PR adds the missing step after setting up default genesis in step 5 on page https://tutorials.cosmos.network/hands-on-exercise/2-ignite-cli-adv/3-game-fifo.html before "FIFO management" to add the required init values in `types/genesis_test.go`

[(Optional: Further notes for reviewers)]

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [ ] Small language/grammar fixes
* [ ] Small content fixes 
* [X] Addition of new content
* [X] Sample code/command updates
* [ ] Platform fixes
* [ ] Other


### before 

```go
go test github.com/noslav/checkers/x/checkers/types
# github.com/noslav/checkers/x/checkers/types_test [github.com/noslav/checkers/x/checkers/types.test]
x/checkers/types/genesis_test.go:71:46: too few values in struct literal of type "github.com/noslav/checkers/x/checkers/types".SystemInfo
FAIL	github.com/noslav/checkers/x/checkers/types [build failed]
FAIL
```
### after

```go
go test github.com/noslav/checkers/x/checkers/types
ok  	github.com/noslav/checkers/x/checkers/types	0.181s
```

This is also related to https://github.com/cosmos/b9-checkers-academy-draft/pull/53 for the same page.
