### PR TITLE
Fix source pointer line for winner by color and escrow errors

### DIFF
--- a/hands-on-exercise/2-ignite-cli-adv/4-game-forfeit.md
+++ b/hands-on-exercise/2-ignite-cli-adv/4-game-forfeit.md
@@ -95,7 +95,7 @@ Your `ForfeitExpiredGames` function will now be called at the end of each block.
 
 Also prepare a new error:
 
-```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/forfeit-game/x/checkers/types/errors.go#L20]
+```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/forfeit-game/x/checkers/types/errors.go#L23]
     var (
         ...
 +      ErrCannotFindWinnerByColor = sdkerrors.Register(ModuleName, 1109, "cannot find winner by color: %s")

--- a/hands-on-exercise/2-ignite-cli-adv/6-payment-winning.md
+++ b/hands-on-exercise/2-ignite-cli-adv/6-payment-winning.md
@@ -165,7 +165,7 @@ checkersModuleAddress := app.AccountKeeper.GetModuleAddress(types.ModuleName)
 
 There are several new error situations that you can enumerate with new variables:
 
-```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/payment-winning/x/checkers/types/errors.go#L23-L28]
+```diff-go [https://github.com/cosmos/b9-checkers-academy-draft/blob/payment-winning/x/checkers/types/errors.go#L24-L29]
     var (
         ...
 +      ErrBlackCannotPay    = sdkerrors.Register(ModuleName, 1110, "black cannot pay the wager")


### PR DESCRIPTION
Documentation content update for Hands-on exervice, Module 2-ignite-cli-adv.

This PR fixes the correct source pointer line for winner by color error

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [ ] Small language/grammar fixes
* [X] Small content fixes 
* [ ] Addition of new content
* [ ] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
