### PR TITLE
docs: Fixed typo in ignite scaffold leaderboard example

### DIFF
--- a/hands-on-exercise/5-ibc-adv/7-ibc-app-leaderboard.md
+++ b/hands-on-exercise/5-ibc-adv/7-ibc-app-leaderboard.md
@@ -30,7 +30,7 @@ Create another folder for your leaderboard chain, and scaffold a chain via Ignit
 <CodeGroupItem title="Local">
 
 ```sh
-$ ignite ignite scaffold chain leaderboard --no-module
+$ ignite scaffold chain leaderboard --no-module
 ```
 
 </CodeGroupItem>


### PR DESCRIPTION
Documentation content update for [Module IBC, Section Create Leaderboard Chain]

This PR fixes a typo in the `ignite scaffold leaderboard` example.

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [ ] Small language/grammar fixes
* [ ] Small content fixes
* [ ] Addition of new content
* [x] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
