### PR TITLE
Fixed Typo on the Academy docs, issue - 1462

### DIFF
--- a/academy/1-what-is-cosmos/1-blockchain-and-cosmos.md
+++ b/academy/1-what-is-cosmos/1-blockchain-and-cosmos.md
@@ -141,7 +141,7 @@ For more on Tendermint, see this helpful [introduction](https://docs.tendermint.
 
 </ExpansionPanel>
 
-Initially, the Interchain was an open-source community project built by the Tendermint team. Since then, the **Interchain Foundation (ICF)** has assisted with the development and launch of the network. The ICF is a Swiss non-profit that raised funds in 2017 to finance the development of open-source projects building on the the Interchain network.
+Initially, the Interchain was an open-source community project built by the Tendermint team. Since then, the **Interchain Foundation (ICF)** has assisted with the development and launch of the network. The ICF is a Swiss non-profit that raised funds in 2017 to finance the development of open-source projects building on the Interchain network.
 
 The founding **vision** of the Interchain is that of an easy development environment for blockchain technology. The Interchain wants to address the main issues of previous blockchain projects and provide interoperability between chains to foster an **internet of blockchains**.
 


### PR DESCRIPTION
Fixes #1462 

Changed from: 
`[building on the the Interchain network.]`

To:
`[building on the Interchain network.]`