### PR TITLE
docs: Custom cosmjs interfaces tutorial update

### DIFF
--- a/tutorials/7-cosmjs/5-create-custom.md
+++ b/tutorials/7-cosmjs/5-create-custom.md
@@ -234,7 +234,7 @@ You can find the same structure in [`query.ts`](https://github.com/confio/cosmjs
 
 ### Proper saving
 
-Commit the extra `.proto` files as well as the compiled ones to your repository so you do not need to recreate them.So add an npm run target, to keep track of how this was done and easily reproduce it in the future when you update a Protobuf file:
+Commit the extra `.proto` files as well as the compiled ones to your repository so you do not need to recreate them. So add an npm run target, to keep track of how this was done and easily reproduce it in the future when you update a Protobuf file:
 
 ```json
 "scripts": {

--- a/tutorials/7-cosmjs/5-create-custom.md
+++ b/tutorials/7-cosmjs/5-create-custom.md
@@ -39,7 +39,7 @@ This exercise assumes that:
 
 1. The library you're creating is in 'myLib'.
 2. Your Protobuf definition files are in `./proto/`.
-2. You want to transpile them into TypeScript in `./src/codegen/`.
+3. You want to transpile them into TypeScript in `./src/codegen/`.
 
 Install `telescope` on your computer globally:
 


### PR DESCRIPTION
Documentation content update for [Section `Create Custom CosmJS Interfaces`]

This PR updates outdated `Create Custom CosmJS Interfaces` section, since the old tutorial of transpiling proto files(using protoc) is not beginner friendly. 
With the new tutorial, users can learn the process in [telescope](https://github.com/cosmology-tech/telescope) way, which is easier to install and transpile proto files.
Some links to [cosmjs-types](https://github.com/confio/cosmjs-types/) are also outdated(current version of cosmjs-types was also generated by telescope), so I updated those too.

[(Optional: Further notes for reviewers)]

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [ ] Small language/grammar fixes
* [ ] Small content fixes
* [x] Addition of new content
* [x] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
