### PR TITLE
fix(ignite): correct the latest ignite URL

### DIFF
--- a/hands-on-exercise/1-ignite-cli/1-ignitecli.md
+++ b/hands-on-exercise/1-ignite-cli/1-ignitecli.md
@@ -95,7 +95,7 @@ This entire exercise was built using the Ignite CLI version noted above. Using a
 If you need to install the latest version of Ignite CLI, use:
 
 ```sh
-$ curl https://get.ignite.com/cli@! | bash
+$ curl https://get.ignite.com/cli! | bash
 ```
 
 When you then run `ignite version`, it prints its version:


### PR DESCRIPTION
According to https://ignite.com, the latest cURL path does not have the `@` character in it

Documentation content update for "Run Your Cosmos Chain: Ignite CLI".

This PR corrects the URL to install the latest version of the Ignite CLI by removing the `@` character.

### Change scope

The changes in this Pull Request include (please tick all that apply):

* [ ] Small language/grammar fixes
* [ ] Small content fixes
* [ ] Addition of new content
* [x] Sample code/command updates
* [ ] Platform fixes
* [ ] Other
